### PR TITLE
Implement ISessionState against ISession

### DIFF
--- a/samples/ClassLibrary/SessionUtils.cs
+++ b/samples/ClassLibrary/SessionUtils.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.SystemWebAdapters.SessionState;
+using Microsoft.AspNetCore.SystemWebAdapters.SessionState.Serialization;
 
 namespace ClassLibrary;
 
@@ -6,7 +6,7 @@ public class SessionUtils
 {
     public static string ApiKey = "test-key";
 
-    public static void RegisterSessionKeys(SessionOptions options)
+    public static void RegisterSessionKeys(SessionSerializerOptions options)
     {
         options.RegisterKey<int>("test-value");
         options.RegisterKey<SessionDemoModel>("SampleSessionItem");

--- a/samples/MvcApp/Global.asax.cs
+++ b/samples/MvcApp/Global.asax.cs
@@ -18,11 +18,9 @@ namespace MvcApp
 
             Application.AddSystemWebAdapters()
                 .AddProxySupport(options => options.UseForwardedHeaders = true)
-                .AddRemoteAppSession(options=>
-                {
-                    options.ApiKey = ClassLibrary.SessionUtils.ApiKey;
-                    ClassLibrary.SessionUtils.RegisterSessionKeys(options);
-                });
+                .AddRemoteAppSession(
+                    options => options.ApiKey = ClassLibrary.SessionUtils.ApiKey,
+                    options => ClassLibrary.SessionUtils.RegisterSessionKeys(options));
         }
     }
 }

--- a/samples/MvcCoreApp/Program.cs
+++ b/samples/MvcCoreApp/Program.cs
@@ -6,12 +6,11 @@ builder.Services.AddReverseProxy().LoadFromConfig(builder.Configuration.GetSecti
 // Add services to the container.
 builder.Services.AddControllersWithViews();
 builder.Services.AddSystemWebAdapters()
+    .AddJsonSessionSerializer(options => ClassLibrary.SessionUtils.RegisterSessionKeys(options))
     .AddRemoteAppSession(options =>
     {
         options.RemoteApp = new(builder.Configuration["ReverseProxy:Clusters:fallbackCluster:Destinations:fallbackApp:Address"]);
         options.ApiKey = ClassLibrary.SessionUtils.ApiKey;
-
-        ClassLibrary.SessionUtils.RegisterSessionKeys(options);
     });
 
 var app = builder.Build();
@@ -36,8 +35,8 @@ app.UseSystemWebAdapters();
 app.UseEndpoints(endpoints =>
 {
     app.MapDefaultControllerRoute();
-        // This method can be used to enable session (or read-only session) on all controllers
-        //.RequireSystemWebAdapterSession();
+    // This method can be used to enable session (or read-only session) on all controllers
+    //.RequireSystemWebAdapterSession();
 
     app.MapReverseProxy();
 });

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/BuiltIn/BuiltInSessionExtensions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/BuiltIn/BuiltInSessionExtensions.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.AspNetCore.SystemWebAdapters.SessionState.BuiltIn;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.SystemWebAdapters;
+
+public static class BuiltInSessionExtensions
+{
+    public static ISystemWebAdapterBuilder AddBuiltInSession(this ISystemWebAdapterBuilder builder, Action<Builder.SessionOptions>? options = null)
+    {
+        if (options is null)
+        {
+            builder.Services.AddSession();
+        }
+        else
+        {
+            builder.Services.AddSession(options);
+        }
+
+        builder.Services.AddSingleton<ISessionManager, BuiltInSessionManager>();
+
+        return builder;
+    }
+}

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/BuiltIn/BuiltInSessionManager.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/BuiltIn/BuiltInSessionManager.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SystemWebAdapters.SessionState.Serialization;
+
+namespace Microsoft.AspNetCore.SystemWebAdapters.SessionState.BuiltIn;
+
+internal class BuiltInSessionManager : ISessionManager
+{
+    private readonly ISessionSerializer _serializer;
+
+    public BuiltInSessionManager(ISessionSerializer serializer)
+    {
+        _serializer = serializer;
+    }
+
+    public Task<ISessionState> CreateAsync(HttpContextCore context, ISessionMetadata metadata)
+        => Task.FromResult<ISessionState>(new BuiltInSessionState(context.Session, _serializer, metadata.IsReadOnly));
+}

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/BuiltIn/BuiltInSessionState.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/BuiltIn/BuiltInSessionState.cs
@@ -1,0 +1,97 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.SystemWebAdapters.SessionState.Serialization;
+
+namespace Microsoft.AspNetCore.SystemWebAdapters.SessionState.BuiltIn;
+
+internal class BuiltInSessionState : ISessionState
+{
+    private readonly ISession _session;
+    private readonly ISessionSerializer _serializer;
+
+    public BuiltInSessionState(ISession session, ISessionSerializer serializer, bool isReadOnly)
+    {
+        _session = session;
+        _serializer = serializer;
+
+        IsReadOnly = isReadOnly;
+    }
+
+    private void CheckReadOnly()
+    {
+        if (IsReadOnly)
+        {
+            throw new InvalidOperationException("Session is readonly");
+        }
+    }
+
+    public object? this[string key]
+    {
+        get => _serializer.Deserialize(key, _session.Get(key));
+        set
+        {
+            CheckReadOnly();
+
+            if (value is null)
+            {
+                _session.Remove(key);
+            }
+            else
+            {
+                _session.Set(key, _serializer.Serialize(key, value));
+            }
+        }
+    }
+
+    public string SessionID => _session.Id;
+
+    public bool IsReadOnly { get; }
+
+    public int Timeout { get; set; } = 20;
+
+    public bool IsNewSession => false;
+
+    public int Count => _session.Keys.Count();
+
+    public bool IsSynchronized => false;
+
+    public object SyncRoot => _session;
+
+    public bool IsAbandoned { get; set; }
+
+    public IEnumerable<string> Keys => _session.Keys;
+
+    public void Clear()
+    {
+        CheckReadOnly();
+        _session.Clear();
+    }
+
+    public async ValueTask CommitAsync(CancellationToken token)
+    {
+        CheckReadOnly();
+
+        if (IsAbandoned)
+        {
+            _session.Clear();
+        }
+
+        await _session.CommitAsync(token);
+    }
+
+    public ValueTask DisposeAsync() => default;
+
+    public void Remove(string key)
+    {
+        CheckReadOnly();
+        _session.Remove(key);
+    }
+}
+

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/Microsoft.AspNetCore.SystemWebAdapters.SessionState.csproj
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/Microsoft.AspNetCore.SystemWebAdapters.SessionState.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netcoreapp3.1;net472</TargetFrameworks>
@@ -42,7 +42,7 @@
     <Compile Include="RemoteSession/RemoteAppSessionStateOptions.cs" />
     <Compile Include="Serialization/SessionValues.cs" />
     <Compile Include="Serialization/SerializedSessionState.cs" />
-    <Compile Include="Serialization/SessionSerializer.Shared.cs" />
+    <Compile Include="Serialization/JsonSessionSerializer.Shared.cs" />
 
     <Reference Include="System.Web" />
 

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/RemoteSession/RemoteAppSessionStateExtensions.Framework.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/RemoteSession/RemoteAppSessionStateExtensions.Framework.cs
@@ -3,16 +3,22 @@
 
 using System;
 using Microsoft.AspNetCore.SystemWebAdapters.SessionState.RemoteSession;
+using Microsoft.AspNetCore.SystemWebAdapters.SessionState.Serialization;
 
 namespace Microsoft.AspNetCore.SystemWebAdapters;
 
 public static class RemoteAppSessionStateExtensions
 {
-    public static ISystemWebAdapterBuilder AddRemoteAppSession(this ISystemWebAdapterBuilder builder, Action<RemoteAppSessionStateOptions> configure)
+    public static ISystemWebAdapterBuilder AddRemoteAppSession(this ISystemWebAdapterBuilder builder, Action<RemoteAppSessionStateOptions> configureRemote, Action<SessionSerializerOptions> configureSerializer)
     {
         var options = new RemoteAppSessionStateOptions();
-        configure(options);
-        builder.Modules.Add(new RemoteSessionModule(options));
+        configureRemote(options);
+
+        var serializerOptions = new SessionSerializerOptions();
+        configureSerializer(serializerOptions);
+        var serializer = new JsonSessionSerializer(serializerOptions.KnownKeys);
+
+        builder.Modules.Add(new RemoteSessionModule(options, serializer));
         return builder;
     }
 }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/RemoteSession/RemoteAppSessionStateExtensions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/RemoteSession/RemoteAppSessionStateExtensions.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Net.Http;
 using Microsoft.AspNetCore.SystemWebAdapters.SessionState.RemoteSession;
-using Microsoft.AspNetCore.SystemWebAdapters.SessionState.Serialization;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.SystemWebAdapters;
@@ -13,7 +12,6 @@ public static class RemoteAppSessionStateExtensions
 {
     public static ISystemWebAdapterBuilder AddRemoteAppSession(this ISystemWebAdapterBuilder builder, Action<RemoteAppSessionStateOptions> configure)
     {
-        builder.Services.AddSingleton<ISessionSerializer, SessionSerializer>();
         builder.Services.AddHttpClient<ISessionManager, RemoteAppSessionStateManager>()
             // Disable cookies in the HTTP client because the service will manage the cookie header directly
             .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler { UseCookies = false });

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/RemoteSession/RemoteAppSessionStateHandler.Framework.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/RemoteSession/RemoteAppSessionStateHandler.Framework.cs
@@ -15,14 +15,14 @@ namespace Microsoft.AspNetCore.SystemWebAdapters.SessionState.RemoteSession;
 internal sealed class RemoteAppSessionStateHandler : HttpTaskAsyncHandler
 {
     private readonly RemoteAppSessionStateOptions _options;
-    private readonly SessionSerializer _serializer;
+    private readonly ISessionSerializer _serializer;
 
     // Track locked sessions awaiting updates or release
     private static readonly ConcurrentDictionary<string, SessionContainer> SessionResponseTasks = new();
 
     public override bool IsReusable => true;
 
-    public RemoteAppSessionStateHandler(RemoteAppSessionStateOptions options)
+    public RemoteAppSessionStateHandler(RemoteAppSessionStateOptions options, ISessionSerializer serializer)
     {
         if (string.IsNullOrEmpty(options.ApiKey))
         {
@@ -30,7 +30,7 @@ internal sealed class RemoteAppSessionStateHandler : HttpTaskAsyncHandler
         }
 
         _options = options;
-        _serializer = new SessionSerializer(options.KnownKeys);
+        _serializer = serializer;
     }
 
     public override async Task ProcessRequestAsync(HttpContext context)

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/RemoteSession/RemoteAppSessionStateOptions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/RemoteSession/RemoteAppSessionStateOptions.cs
@@ -5,12 +5,11 @@
 using System.ComponentModel.DataAnnotations;
 #endif
 
-using System.Collections.Generic;
 using System;
 
 namespace Microsoft.AspNetCore.SystemWebAdapters.SessionState.RemoteSession;
 
-public class RemoteAppSessionStateOptions : SessionOptions
+public class RemoteAppSessionStateOptions
 {
     internal const string ApiKeyHeaderName = "X-SystemWebAdapter-RemoteAppSession-Key";
     internal const string ReadOnlyHeaderName = "X-SystemWebAdapter-RemoteAppSession-ReadOnly";

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/RemoteSession/RemoteSessionModule.Framework.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/RemoteSession/RemoteSessionModule.Framework.cs
@@ -4,21 +4,24 @@
 using System;
 using System.Web;
 using System.Web.SessionState;
+using Microsoft.AspNetCore.SystemWebAdapters.SessionState.Serialization;
 
 namespace Microsoft.AspNetCore.SystemWebAdapters.SessionState.RemoteSession;
 
 internal sealed class RemoteSessionModule : IHttpModule
 {
     private readonly RemoteAppSessionStateOptions _options;
+    private readonly ISessionSerializer _serializer;
 
-    public RemoteSessionModule(RemoteAppSessionStateOptions options)
+    public RemoteSessionModule(RemoteAppSessionStateOptions options, ISessionSerializer serializer)
     {
         _options = options;
+        _serializer = serializer;
     }
 
     public void Init(HttpApplication context)
     {
-        var handler = new RemoteAppSessionStateHandler(_options);
+        var handler = new RemoteAppSessionStateHandler(_options, _serializer);
 
         context.PostMapRequestHandler += MapRemoteSessionHandler;
 

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/Serialization/ISessionSerializer.Framework.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/Serialization/ISessionSerializer.Framework.cs
@@ -14,4 +14,8 @@ public interface ISessionSerializer
     Task DeserializeToAsync(Stream stream, HttpSessionState state, CancellationToken token);
 
     Task SerializeAsync(HttpSessionState state, Stream stream, CancellationToken token);
+
+    byte[] Serialize(string key, object value);
+
+    object? Deserialize(string key, Memory<byte> bytes);
 }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/Serialization/ISessionSerializer.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/Serialization/ISessionSerializer.cs
@@ -1,11 +1,17 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+
 namespace Microsoft.AspNetCore.SystemWebAdapters.SessionState.Serialization;
 
 public interface ISessionSerializer
 {
-    ISessionState? Deserialize(string? data);
+    ISessionState? Deserialize(string? input);
 
     byte[] Serialize(ISessionState state);
+
+    byte[] Serialize(string key, object value);
+
+    object? Deserialize(string key, Memory<byte> bytes);
 }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/Serialization/JsonSessionSerializer.Framework.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/Serialization/JsonSessionSerializer.Framework.cs
@@ -10,7 +10,7 @@ using System.Web.SessionState;
 
 namespace Microsoft.AspNetCore.SystemWebAdapters.SessionState.Serialization;
 
-internal partial class SessionSerializer
+internal partial class JsonSessionSerializer
 {
     public Task SerializeAsync(HttpSessionState state, Stream stream, CancellationToken token)
     {

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/Serialization/JsonSessionSerializer.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/Serialization/JsonSessionSerializer.cs
@@ -2,20 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text.Json;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.SystemWebAdapters.SessionState.RemoteSession;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.SystemWebAdapters.SessionState.Serialization;
 
-internal partial class SessionSerializer
+internal partial class JsonSessionSerializer
 {
-    public SessionSerializer(IOptions<RemoteAppSessionStateOptions> options)
+    public JsonSessionSerializer(IOptions<SessionSerializerOptions> options)
         : this(options.Value.KnownKeys)
     {
     }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/Serialization/SerializedSessionState.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/Serialization/SerializedSessionState.cs
@@ -51,8 +51,6 @@ internal partial class SerializedSessionState
 
     object ISessionState.SyncRoot => ((ICollection)Values).SyncRoot;
 
-    void ISessionState.Add(string name, object value) => Values.Add(name, value);
-
     void ISessionState.Clear() => RawValues?.Clear();
 
     void ISessionState.Remove(string name) => RawValues?.Remove(name);

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/Serialization/SessionSerializerExtensions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/Serialization/SessionSerializerExtensions.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.AspNetCore.SystemWebAdapters.SessionState.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.SystemWebAdapters;
+
+public static class SessionSerializerExtensions
+{
+    public static ISystemWebAdapterBuilder AddJsonSessionSerializer(this ISystemWebAdapterBuilder builder, Action<SessionSerializerOptions>? configure = null)
+    {
+        builder.Services.AddSingleton<ISessionSerializer, JsonSessionSerializer>();
+        var options = builder.Services.AddOptions<SessionSerializerOptions>();
+
+        if (configure is not null)
+        {
+            options.Configure(configure);
+        }
+
+        return builder;
+    }
+}

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/ISessionState.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/ISessionState.cs
@@ -30,11 +30,9 @@ public interface ISessionState : IAsyncDisposable
 
     bool IsAbandoned { get; set; }
 
-    object? this[string name] { get; set; }
+    object? this[string key] { get; set; }
 
-    void Add(string name, object value);
-
-    void Remove(string name);
+    void Remove(string key);
 
     void Clear();
 

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/SessionState/DelegatingSessionState.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/SessionState/DelegatingSessionState.cs
@@ -46,8 +46,6 @@ public abstract class DelegatingSessionState : ISessionState
         set => State.IsAbandoned = value;
     }
 
-    public virtual void Add(string name, object value) => State.Add(name, value);
-
     public virtual void Clear() => State.Clear();
 
     public async ValueTask DisposeAsync()

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/SessionState/Serialization/SessionSerializerOptions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/SessionState/Serialization/SessionSerializerOptions.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.SystemWebAdapters.SessionState.Serialization;
+
+/// <summary>
+/// An interface to register known keys for session objects.
+/// </summary>
+public class SessionSerializerOptions
+{
+    /// <summary>
+    /// Gets the mapping of known session keys to types
+    /// </summary>
+    public IDictionary<string, Type> KnownKeys { get; } = new Dictionary<string, Type>();
+
+    /// <summary>
+    /// Registers a session key name to be of type <typeparamref name="T"/>
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="key"></param>
+    public void RegisterKey<T>(string key) => KnownKeys.Add(key, typeof(T));
+}

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Microsoft.AspNetCore.SystemWebAdapters.csproj
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Microsoft.AspNetCore.SystemWebAdapters.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <SharedFiles Include="Adapters/SessionState/SessionOptions.cs" />
+    <SharedFiles Include="Adapters/SessionState/Serialization/SessionSerializerOptions.cs" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/SessionState/HttpSessionState.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/SessionState/HttpSessionState.cs
@@ -21,7 +21,7 @@ public class HttpSessionState : ICollection
 
     public bool IsReadOnly => _container.IsReadOnly;
 
-    public bool IsNewSession { get; }
+    public bool IsNewSession => _container.IsNewSession;
 
     public int Timeout
     {
@@ -41,7 +41,7 @@ public class HttpSessionState : ICollection
         set => _container[name] = value;
     }
 
-    public void Add(string name, object value) => _container.Add(name, value);
+    public void Add(string name, object value) => _container[name] = value;
 
     public void Remove(string name) => _container.Remove(name);
 

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.SessionState.Tests/BuiltIn/BuiltInSessionState.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.SessionState.Tests/BuiltIn/BuiltInSessionState.cs
@@ -1,0 +1,270 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using AutoFixture;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.SystemWebAdapters.SessionState.Serialization;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.SystemWebAdapters.SessionState.BuiltIn.Tests;
+
+public class BuiltInSessionStateTests
+{
+    private readonly Fixture _fixture;
+
+    public BuiltInSessionStateTests()
+    {
+        _fixture = new Fixture();
+    }
+
+    [Fact]
+    public void GetValue()
+    {
+        // Arrange
+        var key = _fixture.Create<string>();
+        var value = _fixture.CreateMany<byte>().ToArray();
+        var expected = new object();
+
+        var session = new Mock<ISession>();
+        session.Setup(s => s.TryGetValue(key, out value)).Returns(true);
+
+        var serializer = new Mock<ISessionSerializer>();
+        serializer.Setup(s => s.Deserialize(key, value)).Returns(expected);
+
+        var state = new BuiltInSessionState(session.Object, serializer.Object, isReadOnly: false);
+
+        // Act
+        var result = state[key];
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void SetValue()
+    {
+        // Arrange
+        var key = _fixture.Create<string>();
+        var bytes = _fixture.CreateMany<byte>().ToArray();
+        var obj = new object();
+
+        var session = new Mock<ISession>();
+
+        var serializer = new Mock<ISessionSerializer>();
+        serializer.Setup(s => s.Serialize(key, obj)).Returns(bytes);
+
+        var state = new BuiltInSessionState(session.Object, serializer.Object, isReadOnly: false);
+
+        // Act
+        state[key] = obj;
+
+        // Assert
+        session.Verify(s => s.Set(key, bytes), Times.Once);
+    }
+
+    [Fact]
+    public void SetReadOnly()
+    {
+        // Arrange
+        var key = _fixture.Create<string>();
+        var obj = new object();
+
+        var session = new Mock<ISession>();
+        var serializer = new Mock<ISessionSerializer>();
+
+        var state = new BuiltInSessionState(session.Object, serializer.Object, isReadOnly: true);
+
+        // Act/Assert
+        Assert.Throws<InvalidOperationException>(() => state[key] = obj);
+    }
+
+    [Fact]
+    public void SessionId()
+    {
+        // Arrange
+        var id = _fixture.Create<string>();
+
+        var session = new Mock<ISession>();
+        session.Setup(s => s.Id).Returns(id);
+        var serializer = new Mock<ISessionSerializer>();
+
+        var state = new BuiltInSessionState(session.Object, serializer.Object, isReadOnly: true);
+
+        // Act
+        var result = state.SessionID;
+
+        // Assert
+        Assert.Equal(id, result);
+    }
+
+    [InlineData(true)]
+    [InlineData(false)]
+    [Theory]
+    public void IsReadOnly(bool isReadOnly)
+    {
+        // Arrange
+        var session = new Mock<ISession>();
+        var serializer = new Mock<ISessionSerializer>();
+
+        var state = new BuiltInSessionState(session.Object, serializer.Object, isReadOnly: isReadOnly);
+
+        // Act
+        var result = state.IsReadOnly;
+
+        // Assert
+        Assert.Equal(isReadOnly, result);
+    }
+
+    [Fact]
+    public void Count()
+    {
+        // Arrange
+        const int Count = 10;
+        var keys = _fixture.CreateMany<string>(10);
+
+        var session = new Mock<ISession>();
+        session.Setup(s => s.Keys).Returns(keys);
+        var serializer = new Mock<ISessionSerializer>();
+
+        var state = new BuiltInSessionState(session.Object, serializer.Object, isReadOnly: true);
+
+        // Act
+        var result = state.Count;
+
+        // Assert
+        Assert.Equal(Count, result);
+    }
+
+    [Fact]
+    public void Keys()
+    {
+        // Arrange
+        var keys = _fixture.CreateMany<string>(10);
+
+        var session = new Mock<ISession>();
+        session.Setup(s => s.Keys).Returns(keys);
+        var serializer = new Mock<ISessionSerializer>();
+
+        var state = new BuiltInSessionState(session.Object, serializer.Object, isReadOnly: true);
+
+        // Act
+        var result = state.Keys;
+
+        // Assert
+        Assert.Same(keys, result);
+    }
+
+    [Fact]
+    public void Clear()
+    {
+        // Arrange
+        var session = new Mock<ISession>();
+        var serializer = new Mock<ISessionSerializer>();
+
+        var state = new BuiltInSessionState(session.Object, serializer.Object, isReadOnly: false);
+
+        // Act
+        state.Clear();
+
+        // Assert
+        session.Verify(s => s.Clear(), Times.Once);
+    }
+
+    [Fact]
+    public void ClearReadOnly()
+    {
+        // Arrange
+        var session = new Mock<ISession>();
+        var serializer = new Mock<ISessionSerializer>();
+
+        var state = new BuiltInSessionState(session.Object, serializer.Object, isReadOnly: true);
+
+        // Act/Assert
+        Assert.Throws<InvalidOperationException>(() => state.Clear());
+    }
+
+    [Fact]
+    public async Task Commit()
+    {
+        // Arrange
+        var session = new Mock<ISession>();
+        var serializer = new Mock<ISessionSerializer>();
+
+        var state = new BuiltInSessionState(session.Object, serializer.Object, isReadOnly: false);
+
+        // Act
+        await state.CommitAsync(default);
+
+        // Assert
+        session.Verify(s => s.Clear(), Times.Never);
+        session.Verify(s => s.CommitAsync(default), Times.Once);
+    }
+
+    [Fact]
+    public async Task CommitAbandoned()
+    {
+        // Arrange
+        var session = new Mock<ISession>();
+        var serializer = new Mock<ISessionSerializer>();
+
+        var state = new BuiltInSessionState(session.Object, serializer.Object, isReadOnly: false)
+        {
+            IsAbandoned = true
+        };
+
+        // Act
+        await state.CommitAsync(default);
+
+        // Assert
+        session.Verify(s => s.Clear(), Times.Once);
+        session.Verify(s => s.CommitAsync(default), Times.Once);
+    }
+
+    [Fact]
+    public async Task CommitReadOnly()
+    {
+        // Arrange
+        var session = new Mock<ISession>();
+        var serializer = new Mock<ISessionSerializer>();
+
+        var state = new BuiltInSessionState(session.Object, serializer.Object, isReadOnly: true);
+
+        // Act/Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await state.CommitAsync(default));
+    }
+
+    [Fact]
+    public void Remove()
+    {
+        // Arrange
+        var key = _fixture.Create<string>();
+        var session = new Mock<ISession>();
+        var serializer = new Mock<ISessionSerializer>();
+
+        var state = new BuiltInSessionState(session.Object, serializer.Object, isReadOnly: false);
+
+        // Act
+        state.Remove(key);
+
+        // Assert
+        session.Verify(s => s.Remove(key), Times.Once);
+    }
+
+    [Fact]
+    public void RemoveReadOnly()
+    {
+        // Arrange
+        var key = _fixture.Create<string>();
+        var session = new Mock<ISession>();
+        var serializer = new Mock<ISessionSerializer>();
+
+        var state = new BuiltInSessionState(session.Object, serializer.Object, isReadOnly: true);
+
+        // Act/Assert
+        Assert.Throws<InvalidOperationException>(() => state.Remove(key));
+    }
+}

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.SessionState.Tests/Serialization/JsonSessionStateSerializationTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.SessionState.Tests/Serialization/JsonSessionStateSerializationTests.cs
@@ -9,7 +9,7 @@ using KeyDictionary = System.Collections.Generic.Dictionary<string, System.Type>
 
 namespace Microsoft.AspNetCore.SystemWebAdapters.SessionState.Serialization;
 
-public class SessionStateSerializationTests
+public class JsonSessionStateSerializationTests
 {
     [Fact]
     public void NewSession()
@@ -18,7 +18,7 @@ public class SessionStateSerializationTests
         const string PayLoad = @"{
     ""n"": true,
 }";
-        var serializer = new SessionSerializer(new KeyDictionary());
+        var serializer = new JsonSessionSerializer(new KeyDictionary());
 
         // Act
         var result = serializer.Deserialize(PayLoad);
@@ -40,7 +40,7 @@ public class SessionStateSerializationTests
     }
 }";
 
-        var serializer = new SessionSerializer(new KeyDictionary
+        var serializer = new JsonSessionSerializer(new KeyDictionary
         {
             { "Key1", typeof(int) }
         });
@@ -65,7 +65,7 @@ public class SessionStateSerializationTests
     }
 }";
 
-        var serializer = new SessionSerializer(new KeyDictionary
+        var serializer = new JsonSessionSerializer(new KeyDictionary
         {
             { "Key1", typeof(int) }
         }, writeIndented: true);
@@ -113,7 +113,7 @@ public class SessionStateSerializationTests
         ""Key2"": ""hello""
     }
 }";
-        var serializer = new SessionSerializer(new KeyDictionary
+        var serializer = new JsonSessionSerializer(new KeyDictionary
         {
             { "Key1", typeof(int) },
             { "Key2", typeof(string) }
@@ -143,7 +143,7 @@ public class SessionStateSerializationTests
         }
     }
 }";
-        var serializer = new SessionSerializer(new KeyDictionary
+        var serializer = new JsonSessionSerializer(new KeyDictionary
         {
             { "Key1", typeof(SomeObject) }
         });

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/SessionState/HttpSessionStateTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/SessionState/HttpSessionStateTests.cs
@@ -1,0 +1,320 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq;
+using System.Web.SessionState;
+using AutoFixture;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.SystemWebAdapters.Tests.SessionState;
+
+public class HttpSessionStateTests
+{
+    private readonly Fixture _fixture;
+
+    public HttpSessionStateTests()
+    {
+        _fixture = new Fixture();
+    }
+
+    [Fact]
+    public void SessionId()
+    {
+        // Arrange
+        var id = _fixture.Create<string>();
+
+        var session = new Mock<ISessionState>();
+        session.Setup(s => s.SessionID).Returns(id);
+
+        var state = new HttpSessionState(session.Object);
+
+        // Act
+        var result = state.SessionID;
+
+        // Assert
+        Assert.Equal(id, result);
+    }
+
+    [Fact]
+    public void Count()
+    {
+        // Arrange
+        var count = _fixture.Create<int>();
+
+        var session = new Mock<ISessionState>();
+        session.Setup(s => s.Count).Returns(count);
+
+        var state = new HttpSessionState(session.Object);
+
+        // Act
+        var result = state.Count;
+
+        // Assert
+        Assert.Equal(count, result);
+    }
+
+    [InlineData(true)]
+    [InlineData(false)]
+    [Theory]
+    public void IsReadOnly(bool isReadOnly)
+    {
+        // Arrange
+        var session = new Mock<ISessionState>();
+        session.Setup(s => s.IsReadOnly).Returns(isReadOnly);
+
+        var state = new HttpSessionState(session.Object);
+
+        // Act
+        var result = state.IsReadOnly;
+
+        // Assert
+        Assert.Equal(isReadOnly, result);
+    }
+
+    [InlineData(true)]
+    [InlineData(false)]
+    [Theory]
+    public void IsNewSession(bool isNewSession)
+    {
+        // Arrange
+        var session = new Mock<ISessionState>();
+        session.Setup(s => s.IsNewSession).Returns(isNewSession);
+
+        var state = new HttpSessionState(session.Object);
+
+        // Act
+        var result = state.IsNewSession;
+
+        // Assert
+        Assert.Equal(isNewSession, result);
+    }
+
+    [Fact]
+    public void TimeOut()
+    {
+        // Arrange
+        var timeout1 = _fixture.Create<int>();
+        var timeout2 = _fixture.Create<int>();
+
+        var session = new Mock<ISessionState>();
+        session.SetupProperty(s => s.Timeout);
+        session.Object.Timeout = timeout1;
+
+        var state = new HttpSessionState(session.Object);
+
+        // Act
+        var result = state.Timeout;
+        state.Timeout = timeout2;
+
+        // Assert
+        Assert.Equal(timeout1, result);
+        Assert.Equal(timeout2, session.Object.Timeout);
+    }
+
+    [InlineData(true)]
+    [InlineData(false)]
+    [Theory]
+    public void IsSynchronized(bool isSynchronized)
+    {
+        // Arrange
+        var session = new Mock<ISessionState>();
+        session.Setup(s => s.IsSynchronized).Returns(isSynchronized);
+
+        var state = new HttpSessionState(session.Object);
+
+        // Act
+        var result = state.IsSynchronized;
+
+        // Assert
+        Assert.Equal(isSynchronized, result);
+    }
+
+    [Fact]
+    public void SyncRoot()
+    {
+        // Arrange
+        var sync = new object();
+        var session = new Mock<ISessionState>();
+        session.Setup(s => s.SyncRoot).Returns(sync);
+
+        var state = new HttpSessionState(session.Object);
+
+        // Act
+        var result = state.SyncRoot;
+
+        // Assert
+        Assert.Equal(sync, result);
+    }
+
+    [Fact]
+    public void Abandon()
+    {
+        // Arrange
+        var session = new Mock<ISessionState>();
+        session.SetupProperty(s => s.IsAbandoned);
+
+        var state = new HttpSessionState(session.Object);
+
+        // Act
+        state.Abandon();
+
+        // Assert
+        Assert.True(session.Object.IsAbandoned);
+    }
+
+    [Fact]
+    public void Get()
+    {
+        // Arrange
+        var key = _fixture.Create<string>();
+        var value = new object();
+
+        var session = new Mock<ISessionState>();
+        session.Setup(s => s[key]).Returns(value);
+
+        var state = new HttpSessionState(session.Object);
+
+        // Act
+        var result = state[key];
+
+        // Assert
+        Assert.Equal(value, result);
+    }
+
+    [Fact]
+    public void Set()
+    {
+        // Arrange
+        var key = _fixture.Create<string>();
+        var value = new object();
+
+        var session = new Mock<ISessionState>();
+
+        var state = new HttpSessionState(session.Object);
+
+        // Act
+        state[key] = value;
+
+        // Assert
+        session.VerifySet(s => s[key] = value, Times.Once);
+    }
+
+    [Fact]
+    public void Add()
+    {
+        // Arrange
+        var key = _fixture.Create<string>();
+        var value = new object();
+
+        var session = new Mock<ISessionState>();
+        var state = new HttpSessionState(session.Object);
+
+        // Act
+        state.Add(key, value);
+
+        // Assert
+        session.VerifySet(s => s[key] = value, Times.Once);
+    }
+
+    [Fact]
+    public void Remove()
+    {
+        // Arrange
+        var key = _fixture.Create<string>();
+
+        var session = new Mock<ISessionState>();
+        var state = new HttpSessionState(session.Object);
+
+        // Act
+        state.Remove(key);
+
+        // Assert
+        session.Verify(s => s.Remove(key), Times.Once);
+    }
+
+    [Fact]
+    public void RemoveAll()
+    {
+        // Arrange
+        var key = _fixture.Create<string>();
+
+        var session = new Mock<ISessionState>();
+        var state = new HttpSessionState(session.Object);
+
+        // Act
+        state.RemoveAll();
+
+        // Assert
+        session.Verify(s => s.Clear(), Times.Once);
+    }
+
+    [Fact]
+    public void Clear()
+    {
+        // Arrange
+        var key = _fixture.Create<string>();
+
+        var session = new Mock<ISessionState>();
+        var state = new HttpSessionState(session.Object);
+
+        // Act
+        state.Clear();
+
+        // Assert
+        session.Verify(s => s.Clear(), Times.Once);
+    }
+
+    [Fact]
+    public void GetEnumerator()
+    {
+        // Arrange
+        var keys = _fixture.CreateMany<string>(2).ToArray();
+
+        var session = new Mock<ISessionState>();
+        session.Setup(s => s.Keys).Returns(keys);
+
+        var state = new HttpSessionState(session.Object);
+
+        // Act
+        var result = state.GetEnumerator();
+
+        // Assert
+        Assert.True(result.MoveNext());
+        Assert.Equal(keys[0], result.Current);
+        Assert.True(result.MoveNext());
+        Assert.Equal(keys[1], result.Current);
+        Assert.False(result.MoveNext());
+    }
+
+    [Fact]
+    public void CopyTo()
+    {
+        // Arrange
+        var key1 = _fixture.Create<string>();
+        var item1 = new object();
+
+        var key2 = _fixture.Create<string>();
+        var item2 = new object();
+
+        var keys = new[] { key1, key2 };
+
+        var session = new Mock<ISessionState>();
+        session.Setup(s => s.Keys).Returns(keys);
+
+        session.Setup(s => s[key1]).Returns(item1);
+        session.Setup(s => s[key2]).Returns(item2);
+
+        var state = new HttpSessionState(session.Object);
+        var array = new object[3];
+
+        // Act
+        state.CopyTo(array, 1);
+
+        // Assert
+        Assert.Collection(array,
+            item => Assert.Null(item),
+            item => Assert.Equal(item1, item),
+            item => Assert.Equal(item2, item)); ;
+    }
+}


### PR DESCRIPTION
This enables using the in-built ASP.NET Core session through the adapters (i.e. strongly typed). It still requires people to use the adapters to access it, but provides a pathway to remove reliance on the .NET Framework app.
