### PR TITLE
Change default session endpoint path on remote app

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/RemoteSession/RemoteAppSessionStateOptions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/RemoteSession/RemoteAppSessionStateOptions.cs
@@ -36,7 +36,7 @@ public class RemoteAppSessionStateOptions
 
     [Required]
 #endif
-    public string SessionEndpointPath { get; set; } = "/fallback/adapter/session";
+    public string SessionEndpointPath { get; set; } = "/sessionweb-adapters/session";
 
     /// <summary>
     /// Gets or sets the cookie name that the ASP.NET framework app is expecting to hold the session id

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/RemoteSession/RemoteAppSessionStateOptions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/RemoteSession/RemoteAppSessionStateOptions.cs
@@ -36,7 +36,7 @@ public class RemoteAppSessionStateOptions
 
     [Required]
 #endif
-    public string SessionEndpointPath { get; set; } = "/sessionweb-adapters/session";
+    public string SessionEndpointPath { get; set; } = "/systemweb-adapters/session";
 
     /// <summary>
     /// Gets or sets the cookie name that the ASP.NET framework app is expecting to hold the session id


### PR DESCRIPTION
We no longer need the `/fallback` prefix to ensure we go directly to the
remote app so removing that.
