### PR TITLE
Fix the session handler to catch operation canceled exceptions

### DIFF
--- a/test/Microsoft.AspNetCore.SystemWebAdapters.SessionState.Framework.Tests/RemoteSession/GetWriteableSessionHandlerTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.SessionState.Framework.Tests/RemoteSession/GetWriteableSessionHandlerTests.cs
@@ -76,7 +76,9 @@ public class GetWriteableSessionHandlerTests
         response.Verify(r => r.FlushAsync(), Times.Once);
 
         callback!();
-        await Assert.ThrowsAsync<TaskCanceledException>(() => task);
+
+        var exception = await Record.ExceptionAsync(() => task);
+        Assert.Null(exception);
 
         // Assert
         Assert.Equal(200, response.Object.StatusCode);
@@ -133,7 +135,9 @@ public class GetWriteableSessionHandlerTests
         response.Verify(r => r.FlushAsync(), Times.Once);
 
         cts.Cancel();
-        await Assert.ThrowsAsync<TaskCanceledException>(() => task);
+
+        var exception = await Record.ExceptionAsync(() => task);
+        Assert.Null(exception);
 
         // Assert
         Assert.Equal(200, response.Object.StatusCode);


### PR DESCRIPTION
This fixes an issue in the GetWriteableSessionHandler that was causing shared session not to work properly. 

The (expected) OperationCanceledException when storing session state triggers the cancelation token that getting the session state is waiting on was causing ASP.NET's request processing to bail out and not successfully store updated session state.

This fix just catches the exception so that session updates are stored as expected on the ASP.NET side.