### PR TITLE
Add middleware to restrict concurrency

### DIFF
--- a/docs/usage_guidance.md
+++ b/docs/usage_guidance.md
@@ -39,8 +39,16 @@ app.UseRequestLocalization();
 
 In ASP.NET Framework, a request had thread-affinity and `HttpContext.Current` would only be available if on that thread. ASP.NET Core does not have this guarantee so `HttpContext.Current` will be available within the same async context, but no guarantees about threads are made.
 
-**Recommendation**: If reading/writing to the `HttpContext`, you must ensure you are doing so in a single-threaded way.
+**Recommendation**: If reading/writing to the `HttpContext`, you must ensure you are doing so in a single-threaded way. You can force a request to never run concurrently on any async context by setting the `ISingleThreadedRequestMetadata`. There is an implementation available to add to controllers with `SingleThreadedRequestAttribute`:
 
+
+```csharp
+[SingleThreadedRequest]
+public class SomeController : Controller
+{
+    ...
+} 
+```
 
 ## `HttpContext.Request` may need to be prebuffered
 

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/ISingleThreadedRequestMetadata.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/ISingleThreadedRequestMetadata.cs
@@ -1,0 +1,9 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.SystemWebAdapters;
+
+public interface ISingleThreadedRequestMetadata
+{
+    bool IsEnabled { get; }
+}

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/SingleThreadedRequestAttribute.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/SingleThreadedRequestAttribute.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.AspNetCore.SystemWebAdapters;
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+public sealed class SingleThreadedRequestAttribute : Attribute, ISingleThreadedRequestMetadata
+{
+    public bool IsEnabled { get; set; } = true;
+}

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/SingleThreadedRequestMiddleware.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/SingleThreadedRequestMiddleware.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.SystemWebAdapters;
+
+internal class SingleThreadedRequestMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ConcurrentExclusiveSchedulerPair _schedule;
+
+    public SingleThreadedRequestMiddleware(RequestDelegate next)
+    {
+        _next = next;
+        _schedule = new ConcurrentExclusiveSchedulerPair(TaskScheduler.Default, 1);
+    }
+
+    public Task InvokeAsync(HttpContextCore context)
+        => context.GetEndpoint()?.Metadata.GetMetadata<ISingleThreadedRequestMetadata>() is { IsEnabled: true }
+            ? EnsureSingleThreaded(context)
+            : _next(context);
+
+    private Task EnsureSingleThreaded(HttpContextCore context)
+        => Task.Factory.StartNew(() => _next(context), context.RequestAborted, TaskCreationOptions.DenyChildAttach, _schedule.ExclusiveScheduler).Unwrap();
+}

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/SystemWebAdaptersExtensions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/SystemWebAdaptersExtensions.cs
@@ -30,6 +30,7 @@ namespace Microsoft.AspNetCore.SystemWebAdapters
             app.UseMiddleware<PreBufferRequestStreamMiddleware>();
             app.UseMiddleware<SessionMiddleware>();
             app.UseMiddleware<BufferResponseStreamMiddleware>();
+            app.UseMiddleware<SingleThreadedRequestMiddleware>();
         }
 
         /// <summary>


### PR DESCRIPTION
This adds middleware that will turn a request into (logically) a single-threaded request. This helps mimic some of the behavior that was seen on ASP.NET Framework where there was a concept of a request thread. Since ASP.NET Core is not tied to a specific thread, that model does not translate directly. However, by enabling this, it will limit concurrent access to items within the flow of a request.
