### PR TITLE
Fix aspnetcore Wrapped Sessions

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/Wrapped/AspNetCoreSessionManager.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/Wrapped/AspNetCoreSessionManager.cs
@@ -22,5 +22,5 @@ internal class AspNetCoreSessionManager : ISessionManager
     }
 
     public Task<ISessionState> CreateAsync(HttpContextCore context, ISessionMetadata metadata)
-        => Task.FromResult<ISessionState>(new AspNetCoreSessionState(context.Session, _serializer, _loggerFactory, _options.Value.ThrowOnUnknownSessionKey, metadata.IsReadOnly));
+        => Task.FromResult<ISessionState>(new AspNetCoreSessionState(context.Session, _serializer, _loggerFactory, metadata.IsReadOnly, _options.Value.ThrowOnUnknownSessionKey));
 }

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.SessionState.Tests/Wrapped/AspNetCoreSessionState.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.SessionState.Tests/Wrapped/AspNetCoreSessionState.cs
@@ -6,7 +6,9 @@ using System.Linq;
 using System.Threading.Tasks;
 using AutoFixture;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.SystemWebAdapters.SessionState.Serialization;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
@@ -104,6 +106,21 @@ public class AspNetCoreSessionStateTests
     {
         // Arrange
         using var state = CreateSesionState(isReadOnly: isReadOnly);
+
+        // Act
+        var result = state.IsReadOnly;
+
+        // Assert
+        Assert.Equal(isReadOnly, result);
+    }
+
+    [InlineData(true)]
+    [InlineData(false)]
+    [Theory]
+    public async Task IsReadOnlySessionManager(bool isReadOnly)
+    {
+        // Arrange
+        using var state = await CreateSessionStateFromSessionManager(isReadOnly: isReadOnly);
 
         // Act
         var result = state.IsReadOnly;
@@ -256,5 +273,18 @@ public class AspNetCoreSessionStateTests
         var loggerFactory = new Mock<ILoggerFactory>();
 
         return new AspNetCoreSessionState(session.Object, serializer.Object, loggerFactory.Object, isReadOnly: isReadOnly, throwOnUnknown: throwOnUnknown);
+    }
+    private static async Task<ISessionState> CreateSessionStateFromSessionManager(Mock<ISession>? session = null, Mock<ISessionKeySerializer>? serializer = null, bool isReadOnly = false, bool throwOnUnknown = false)
+    {
+        session ??= new Mock<ISession>();
+        serializer ??= new Mock<ISessionKeySerializer>();
+        var loggerFactory = new Mock<ILoggerFactory>();
+        var httpContextCore = new Mock<HttpContextCore>();
+        httpContextCore.Setup(s => s.Session).Returns(session.Object);
+        var sessionSerializerOptions = new SessionSerializerOptions() {ThrowOnUnknownSessionKey = throwOnUnknown};
+        var options = Options.Create(sessionSerializerOptions);
+
+        var aspNetCoreSessionManager = new AspNetCoreSessionManager(serializer.Object, loggerFactory.Object, options);
+        return await aspNetCoreSessionManager.CreateAsync(httpContextCore.Object, new SessionAttribute(){IsReadOnly = isReadOnly});
     }
 }

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.SessionState.Tests/Wrapped/AspNetCoreSessionState.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.SessionState.Tests/Wrapped/AspNetCoreSessionState.cs
@@ -274,6 +274,7 @@ public class AspNetCoreSessionStateTests
 
         return new AspNetCoreSessionState(session.Object, serializer.Object, loggerFactory.Object, isReadOnly: isReadOnly, throwOnUnknown: throwOnUnknown);
     }
+
     private static async Task<ISessionState> CreateSessionStateFromSessionManager(Mock<ISession>? session = null, Mock<ISessionKeySerializer>? serializer = null, bool isReadOnly = false, bool throwOnUnknown = false)
     {
         session ??= new Mock<ISession>();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the systemweb-adapters repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](../CONTRIBUTING.md) and [Code of Conduct](../CODE-OF-CONDUCT.md).
- [ ] You've included unit tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**PR Title**
Fix aspnetcore wrapped session

**PR Description**
When activating aspnetcore wrapped session (.WrapAspNetCoreSession()) the session manager is creating AspNetCoreSessionState object swapping isReadOnly and throwOnUnknown attributes
