### PR TITLE
Add HttpContext.IsDebuggingEnabled

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpContext.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpContext.cs
@@ -7,9 +7,11 @@ using System.Security.Claims;
 using System.Security.Principal;
 using System.Web.Caching;
 using System.Web.SessionState;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.SystemWebAdapters;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace System.Web;
 
@@ -40,6 +42,11 @@ public class HttpContext : IServiceProvider
     public HttpServerUtility Server => _server ??= new(_context);
 
     public Cache Cache => _context.RequestServices.GetRequiredService<Cache>();
+
+    /// <summary>
+    /// Gets whether the current request is running in the development environment.
+    /// </summary>
+    public bool IsDebuggingEnabled => _context.RequestServices.GetRequiredService<IWebHostEnvironment>().IsDevelopment();
 
     public IPrincipal User
     {

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpContextBase.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpContextBase.cs
@@ -27,6 +27,8 @@ namespace System.Web
             set => throw new NotImplementedException();
         }
 
+        public virtual bool IsDebuggingEnabled => throw new NotImplementedException();
+
         public virtual HttpServerUtilityBase Server => throw new NotImplementedException();
 
         public virtual HttpSessionStateBase? Session => throw new NotImplementedException();

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpContextWrapper.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpContextWrapper.cs
@@ -27,6 +27,8 @@ namespace System.Web
 
         public override IDictionary Items => _context.Items;
 
+        public override bool IsDebuggingEnabled => _context.IsDebuggingEnabled;
+
         public override HttpRequestBase Request
         {
             get

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Ref.Standard.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Ref.Standard.cs
@@ -45,6 +45,7 @@ namespace System.Web
         internal HttpContext() { }
         public System.Web.Caching.Cache Cache { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public static System.Web.HttpContext Current { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
+        public bool IsDebuggingEnabled { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public System.Collections.IDictionary Items { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public System.Web.HttpRequest Request { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public System.Web.HttpResponse Response { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
@@ -57,6 +58,7 @@ namespace System.Web
     public partial class HttpContextBase : System.IServiceProvider
     {
         protected HttpContextBase() { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
+        public virtual bool IsDebuggingEnabled { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public virtual System.Collections.IDictionary Items { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public virtual System.Web.HttpRequestBase Request { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public virtual System.Web.HttpResponseBase Response { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
@@ -68,6 +70,7 @@ namespace System.Web
     public partial class HttpContextWrapper : System.Web.HttpContextBase
     {
         public HttpContextWrapper(System.Web.HttpContext httpContext) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
+        public override bool IsDebuggingEnabled { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public override System.Collections.IDictionary Items { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public override System.Web.HttpRequestBase Request { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }
         public override System.Web.HttpResponseBase Response { get { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");} }


### PR DESCRIPTION
On ASP.NET, this was tied to the compilation model used for controls. Since this doesn't exist on framework, it makes most sense to expose whether the current environment is development.
