### PR TITLE
Update HTTPS server variable in ProxyHeaderModule

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/ForwardedHost.Shared.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/ForwardedHost.Shared.cs
@@ -12,19 +12,23 @@ namespace Microsoft.AspNetCore.SystemWebAdapters;
 
 internal readonly struct ForwardedHost
 {
+    private readonly int? _port;
+
     public ForwardedHost(string host, string? proto)
     {
         var hostString = HostString.FromUriComponent(host);
 
+        IsSecure = string.Equals("https", proto, StringComparison.OrdinalIgnoreCase);
         ServerName = hostString.Host;
-        Port = hostString.Port is int p ? p : GetDefaultPort(proto);
+        _port = hostString.Port;
     }
 
-    private static int GetDefaultPort(string? proto)
-        => string.Equals("https", proto, StringComparison.OrdinalIgnoreCase) ? 443 : 80;
+    private int DefaultPort => IsSecure ? 443 : 80;
+
+    public bool IsSecure { get; }
 
     public string ServerName { get; }
 
-    public int Port { get; }
+    public int Port => _port is int port ? port : DefaultPort;
 }
 #endif

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/ProxyOptions.Framework.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/ProxyOptions.Framework.cs
@@ -1,15 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Globalization;
-
 namespace Microsoft.AspNetCore.SystemWebAdapters;
 
 public class ProxyOptions
 {
-    private string? _port;
-    private string? _serverHostString;
-
     /// <summary>
     /// Gets or sets whether the X-Forwarded-* headers should be used for incoming requests.
     /// </summary>
@@ -31,8 +26,4 @@ public class ProxyOptions
     /// Gets or sets the scheme.
     /// </summary>
     public string Scheme { get; set; } = "https";
-
-    internal string ServerPortString => _port ??= ServerPort.ToString(CultureInfo.InvariantCulture);
-
-    internal string ServerHostString => _serverHostString ??= $"{ServerName}:{ServerPortString}";
 }

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Framework.Tests/ProxyHeaderModuleTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Framework.Tests/ProxyHeaderModuleTests.cs
@@ -17,6 +17,9 @@ public class ProxyHeaderModuleTests
     private const string RemoteHost = "REMOTE_HOST";
     private const string ServerName = "SERVER_NAME";
     private const string ServerPort = "SERVER_PORT";
+    private const string ServerHttps = "HTTPS";
+    private const string On = "ON";
+    private const string Off = "OFF";
 
     [Fact]
     public void NoHeaderChange()
@@ -57,6 +60,7 @@ public class ProxyHeaderModuleTests
         Assert.Null(serverVariables[RemoteHost]);
         Assert.Equal("localhost:81", requestHeaders[Host]);
         Assert.Null(requestHeaders[options.OriginalHostHeaderName]);
+        Assert.Equal(Off, serverVariables[ServerHttps]);
     }
 
     [Fact]
@@ -81,6 +85,7 @@ public class ProxyHeaderModuleTests
         Assert.Null(serverVariables[RemoteHost]);
         Assert.Equal("localhost", requestHeaders[Host]);
         Assert.Null(requestHeaders[options.OriginalHostHeaderName]);
+        Assert.Equal(Off, serverVariables[ServerHttps]);
     }
 
     [Fact]
@@ -106,6 +111,7 @@ public class ProxyHeaderModuleTests
         Assert.Null(serverVariables[RemoteHost]);
         Assert.Equal("localhost", requestHeaders[Host]);
         Assert.Null(requestHeaders[options.OriginalHostHeaderName]);
+        Assert.Equal(Off, serverVariables[ServerHttps]);
     }
 
     [Fact]
@@ -132,6 +138,7 @@ public class ProxyHeaderModuleTests
         Assert.Null(serverVariables[RemoteHost]);
         Assert.Equal("localhost", requestHeaders[Host]);
         Assert.Equal("localhost2:90", requestHeaders[options.OriginalHostHeaderName]);
+        Assert.Equal(Off, serverVariables[ServerHttps]);
     }
 
     [Fact]
@@ -157,6 +164,7 @@ public class ProxyHeaderModuleTests
         Assert.Null(serverVariables[RemoteHost]);
         Assert.Equal("localhost", requestHeaders[Host]);
         Assert.Null(requestHeaders[options.OriginalHostHeaderName]);
+        Assert.Equal(On, serverVariables[ServerHttps]);
     }
 
     [Fact]
@@ -182,6 +190,7 @@ public class ProxyHeaderModuleTests
         Assert.Null(serverVariables[RemoteHost]);
         Assert.Equal("::1", requestHeaders[Host]);
         Assert.Null(requestHeaders[options.OriginalHostHeaderName]);
+        Assert.Equal(On, serverVariables[ServerHttps]);
     }
 
     [Fact]
@@ -207,6 +216,7 @@ public class ProxyHeaderModuleTests
         Assert.Null(serverVariables[RemoteHost]);
         Assert.Equal("[::1]:81", requestHeaders[Host]);
         Assert.Null(requestHeaders[options.OriginalHostHeaderName]);
+        Assert.Equal(On, serverVariables[ServerHttps]);
     }
 
     [Fact]
@@ -230,6 +240,7 @@ public class ProxyHeaderModuleTests
         Assert.Null(requestHeaders[Host]);
         Assert.Null(serverVariables[ServerName]);
         Assert.Null(serverVariables[ServerPort]);
+        Assert.Null(serverVariables[ServerHttps]);
         Assert.Equal(ForwardedForValue, serverVariables[RemoteAddress]);
         Assert.Equal(ForwardedForValue, serverVariables[RemoteHost]);
         Assert.Null(requestHeaders[options.OriginalHostHeaderName]);


### PR DESCRIPTION
We were updating `SERVER_PROTOCOL` which is not used in IIS for HTTP/HTTPS, but rather the version of HTTP. Instead, we need to update the HTTPS server variable.

Fixes #118
