### PR TITLE
Set the HTTPS server variables as lower case since .NET Framework expects this

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/ProxyHeaderModule.Framework.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/ProxyHeaderModule.Framework.cs
@@ -20,6 +20,8 @@ internal class ProxyHeaderModule : IHttpModule
     private const string ServerPort = "SERVER_PORT";
     private const string ForwardedProto = "x-forwarded-proto";
     private const string ForwardedHost = "x-forwarded-host";
+    
+    // ASP.NET expects lowercase values for HTTPS, not uppercase as the docs may indicate
     private const string On = "on";
     private const string Off = "off";
 

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/ProxyHeaderModule.Framework.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/ProxyHeaderModule.Framework.cs
@@ -20,8 +20,8 @@ internal class ProxyHeaderModule : IHttpModule
     private const string ServerPort = "SERVER_PORT";
     private const string ForwardedProto = "x-forwarded-proto";
     private const string ForwardedHost = "x-forwarded-host";
-    private const string On = "ON";
-    private const string Off = "OFF";
+    private const string On = "on";
+    private const string Off = "off";
 
     private readonly IOptions<ProxyOptions> _options;
 

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Framework.Tests/ProxyHeaderModuleTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Framework.Tests/ProxyHeaderModuleTests.cs
@@ -18,8 +18,8 @@ public class ProxyHeaderModuleTests
     private const string ServerName = "SERVER_NAME";
     private const string ServerPort = "SERVER_PORT";
     private const string ServerHttps = "HTTPS";
-    private const string On = "ON";
-    private const string Off = "OFF";
+    private const string On = "on";
+    private const string Off = "off";
 
     [Fact]
     public void NoHeaderChange()


### PR DESCRIPTION


<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the systemweb-adapters repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](../CONTRIBUTING.md) and [Code of Conduct](../CODE-OF-CONDUCT.md).
- [x] You've included unit tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**PR Title**
Set the HTTPS server variables as lower case since .NET Framework expects this

**PR Description**
System.Web.WorkerRequest checks if the HTTPS server variable equals "on" to determine if a request IsSecure. This check is case sensitive. When this check fails the Request.Url is returned without https.
https://referencesource.microsoft.com/#System.Web/Hosting/IIS7WorkerRequest.cs,abb2c5b4bea0c0aa

Addresses #125
