### PR TITLE
Add async overload on .NET 6 for TransmitFile/WriteFile

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters/ExcludedApis.txt
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/ExcludedApis.txt
@@ -1,5 +1,6 @@
 T:Microsoft.AspNetCore.SystemWebAdapters.SystemWebAdaptersExtensions
 T:Microsoft.AspNetCore.SystemWebAdapters.ISystemWebAdapterBuilder
+T:System.Web.HttpResponseAsyncExtensions
 
 # Prebuffering
 T:Microsoft.AspNetCore.SystemWebAdapters.IPreBufferRequestStreamMetadata

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponse.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponse.cs
@@ -5,8 +5,6 @@ using System.Collections.Specialized;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
@@ -241,30 +239,15 @@ namespace System.Web
             }
         }
 
-#if NET6_0_OR_GREATER
-        public Task WriteFileAsync(string filename, CancellationToken token)
-            => TransmitFileAsync(filename, token);
-
         [Obsolete(UseWriteFileAsync)]
-#endif
         public void WriteFile(string filename)
             => TransmitFile(filename);
 
-#if NET6_0_OR_GREATER
-        public Task TransmitFileAsync(string filename, CancellationToken token)
-            => TransmitFileAsync(filename, 0, -1, token);
-
         [Obsolete(UseTransmitFileAsync)]
-#endif
         public void TransmitFile(string filename)
             => TransmitFile(filename, 0, -1);
 
-#if NET6_0_OR_GREATER
-        public Task TransmitFileAsync(string filename, long offset, long length, CancellationToken token)
-            => _response.SendFileAsync(filename, offset, length >= 0 ? length : null, token);
-
         [Obsolete(UseTransmitFileAsync)]
-#endif
         public void TransmitFile(string filename, long offset, long length)
             => _response.SendFileAsync(filename, offset, length >= 0 ? length : null).GetAwaiter().GetResult();
 

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponse.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponse.cs
@@ -36,7 +36,7 @@ namespace System.Web
             _response = response;
         }
 
-        private IHttpRequestAdapterFeature AdapterFeature => _adapterFeature ??= _response.HttpContext.Features.Get<IHttpRequestAdapterFeature>()
+        internal IHttpRequestAdapterFeature AdapterFeature => _adapterFeature ??= _response.HttpContext.Features.Get<IHttpRequestAdapterFeature>()
             ?? throw new InvalidOperationException($"Response buffering must be enabled on this endpoint for this API via the {nameof(BufferResponseStreamAttribute)} metadata item");
 
         internal ResponseHeaders TypedHeaders => _typedHeaders ??= new(_response.Headers);

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponseAsyncExtensions.Shared.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponseAsyncExtensions.Shared.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+#if NET6_0_OR_GREATER
+using Microsoft.AspNetCore.SystemWebAdapters;
+using Microsoft.AspNetCore.Http;
+#endif
+
+namespace System.Web;
+
+public static class HttpResponseAsyncExtensions
+{
+    public static Task WriteFileAsync(this HttpResponse response, string filename, CancellationToken token)
+#if NET6_0_OR_GREATER
+        => response.TransmitFileAsync(filename, token);
+#else
+    {
+        response.WriteFile(filename);
+        return Task.CompletedTask;
+    }
+#endif
+
+    public static Task TransmitFileAsync(this HttpResponse response, string filename, long offset, long length, CancellationToken token)
+#if NET6_0_OR_GREATER
+        => response.UnwrapAdapter().SendFileAsync(filename, offset, length >= 0 ? length : null, token);
+#else
+    {
+        response.TransmitFile(filename, offset, length);
+        return Task.CompletedTask;
+    }
+#endif
+
+    public static Task TransmitFileAsync(this HttpResponse response, string filename, CancellationToken token)
+        => response.TransmitFileAsync(filename, 0, -1, token);
+}

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponseAsyncExtensions.Shared.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponseAsyncExtensions.Shared.cs
@@ -9,6 +9,10 @@ using Microsoft.AspNetCore.SystemWebAdapters;
 using Microsoft.AspNetCore.Http;
 #endif
 
+#if NETSTANDARD2_0
+#pragma warning disable CS0618 // Type or member is obsolete
+#endif
+
 namespace System.Web;
 
 public static class HttpResponseAsyncExtensions
@@ -29,6 +33,16 @@ public static class HttpResponseAsyncExtensions
 #else
     {
         response.TransmitFile(filename, offset, length);
+        return Task.CompletedTask;
+    }
+#endif
+
+    public static Task EndAsync(this HttpResponse response)
+#if NET6_0_OR_GREATER
+        => response.AdapterFeature.EndAsync();
+#else
+    {
+        response.End();
         return Task.CompletedTask;
     }
 #endif

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponseBase.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponseBase.cs
@@ -105,25 +105,13 @@ namespace System.Web
 
         public virtual void ClearHeaders() => throw new NotImplementedException();
 
-#if NET6_0_OR_GREATER
-        public virtual Task WriteFileAsync(string filename, CancellationToken token) => throw new NotImplementedException();
-
         [Obsolete(HttpResponse.UseWriteFileAsync)]
-#endif
         public virtual void WriteFile(string filename) => throw new NotImplementedException();
 
-#if NET6_0_OR_GREATER
-        public virtual Task TransmitFileAsync(string filename, CancellationToken token) => throw new NotImplementedException();
-
         [Obsolete(HttpResponse.UseTransmitFileAsync)]
-#endif
         public virtual void TransmitFile(string filename) => throw new NotImplementedException();
 
-#if NET6_0_OR_GREATER
-        public virtual Task TransmitFileAsync(string filename, long offset, long length, CancellationToken token) => throw new NotImplementedException();
-
         [Obsolete(HttpResponse.UseTransmitFileAsync)]
-#endif
         public virtual void TransmitFile(string filename, long offset, long length) => throw new NotImplementedException();
     }
 }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponseBase.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponseBase.cs
@@ -5,6 +5,8 @@ using System.Collections.Specialized;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.Web
 {
@@ -103,10 +105,25 @@ namespace System.Web
 
         public virtual void ClearHeaders() => throw new NotImplementedException();
 
+#if NET6_0_OR_GREATER
+        public virtual Task WriteFileAsync(string filename, CancellationToken token) => throw new NotImplementedException();
+
+        [Obsolete(HttpResponse.UseWriteFileAsync)]
+#endif
         public virtual void WriteFile(string filename) => throw new NotImplementedException();
 
+#if NET6_0_OR_GREATER
+        public virtual Task TransmitFileAsync(string filename, CancellationToken token) => throw new NotImplementedException();
+
+        [Obsolete(HttpResponse.UseTransmitFileAsync)]
+#endif
         public virtual void TransmitFile(string filename) => throw new NotImplementedException();
 
+#if NET6_0_OR_GREATER
+        public virtual Task TransmitFileAsync(string filename, long offset, long length, CancellationToken token) => throw new NotImplementedException();
+
+        [Obsolete(HttpResponse.UseTransmitFileAsync)]
+#endif
         public virtual void TransmitFile(string filename, long offset, long length) => throw new NotImplementedException();
     }
 }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponseWrapper.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponseWrapper.cs
@@ -109,25 +109,13 @@ namespace System.Web
 
         public override void End() => _response.End();
 
-#if NET6_0_OR_GREATER
-        public override Task TransmitFileAsync(string filename, CancellationToken token) => _response.TransmitFileAsync(filename, token);
-
         [Obsolete(HttpResponse.UseTransmitFileAsync)]
-#endif
         public override void TransmitFile(string filename) => _response.TransmitFile(filename);
 
-#if NET6_0_OR_GREATER
-        public override Task TransmitFileAsync(string filename, long offset, long length, CancellationToken token) => _response.TransmitFileAsync(filename, offset, length, token);
-
         [Obsolete(HttpResponse.UseTransmitFileAsync)]
-#endif
         public override void TransmitFile(string filename, long offset, long length) => _response.TransmitFile(filename, offset, length);
 
-#if NET6_0_OR_GREATER
-        public override Task WriteFileAsync(string filename, CancellationToken token) => _response.WriteFileAsync(filename, token);
-
         [Obsolete(HttpResponse.UseWriteFileAsync)]
-#endif
         public override void WriteFile(string filename) => _response.WriteFile(filename);
     }
 }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponseWrapper.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponseWrapper.cs
@@ -4,6 +4,8 @@
 using System.Collections.Specialized;
 using System.IO;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.Web
 {
@@ -107,10 +109,25 @@ namespace System.Web
 
         public override void End() => _response.End();
 
+#if NET6_0_OR_GREATER
+        public override Task TransmitFileAsync(string filename, CancellationToken token) => _response.TransmitFileAsync(filename, token);
+
+        [Obsolete(HttpResponse.UseTransmitFileAsync)]
+#endif
         public override void TransmitFile(string filename) => _response.TransmitFile(filename);
 
+#if NET6_0_OR_GREATER
+        public override Task TransmitFileAsync(string filename, long offset, long length, CancellationToken token) => _response.TransmitFileAsync(filename, offset, length, token);
+
+        [Obsolete(HttpResponse.UseTransmitFileAsync)]
+#endif
         public override void TransmitFile(string filename, long offset, long length) => _response.TransmitFile(filename, offset, length);
 
+#if NET6_0_OR_GREATER
+        public override Task WriteFileAsync(string filename, CancellationToken token) => _response.WriteFileAsync(filename, token);
+
+        [Obsolete(HttpResponse.UseWriteFileAsync)]
+#endif
         public override void WriteFile(string filename) => _response.WriteFile(filename);
     }
 }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Microsoft.AspNetCore.SystemWebAdapters.csproj
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Microsoft.AspNetCore.SystemWebAdapters.csproj
@@ -41,6 +41,7 @@
     <Compile Remove="**/*" />
     <Compile Include="Properties/PropertyInfo.cs" />
     <Compile Include="Ref.Standard.cs" />
+    <Compile Include="HttpResponseAsyncExtensions.Shared.cs" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Ref.Standard.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Ref.Standard.cs
@@ -274,11 +274,14 @@ namespace System.Web
         public void RedirectPermanent(string url) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
         public void RedirectPermanent(string url, bool endResponse) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
         public void SetCookie(System.Web.HttpCookie cookie) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
+        [System.ObsoleteAttribute("Use TransmitFileAsync instead as this will cause sync over async")]
         public void TransmitFile(string filename) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
+        [System.ObsoleteAttribute("Use TransmitFileAsync instead as this will cause sync over async")]
         public void TransmitFile(string filename, long offset, long length) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
         public void Write(char ch) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
         public void Write(object obj) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
         public void Write(string s) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
+        [System.ObsoleteAttribute("Use WriteFileAsync instead as this will cause sync over async")]
         public void WriteFile(string filename) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
     }
     public partial class HttpResponseBase
@@ -307,11 +310,14 @@ namespace System.Web
         public virtual void ClearHeaders() { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
         public virtual void End() { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
         public virtual void SetCookie(System.Web.HttpCookie cookie) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
+        [System.ObsoleteAttribute("Use TransmitFileAsync instead as this will cause sync over async")]
         public virtual void TransmitFile(string filename) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
+        [System.ObsoleteAttribute("Use TransmitFileAsync instead as this will cause sync over async")]
         public virtual void TransmitFile(string filename, long offset, long length) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
         public virtual void Write(char ch) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
         public virtual void Write(object obj) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
         public virtual void Write(string s) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
+        [System.ObsoleteAttribute("Use WriteFileAsync instead as this will cause sync over async")]
         public virtual void WriteFile(string filename) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
     }
     public partial class HttpResponseWrapper : System.Web.HttpResponseBase
@@ -340,11 +346,14 @@ namespace System.Web
         public override void ClearHeaders() { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
         public override void End() { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
         public override void SetCookie(System.Web.HttpCookie cookie) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
+        [System.ObsoleteAttribute("Use TransmitFileAsync instead as this will cause sync over async")]
         public override void TransmitFile(string filename) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
+        [System.ObsoleteAttribute("Use TransmitFileAsync instead as this will cause sync over async")]
         public override void TransmitFile(string filename, long offset, long length) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
         public override void Write(char ch) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
         public override void Write(object obj) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
         public override void Write(string s) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
+        [System.ObsoleteAttribute("Use WriteFileAsync instead as this will cause sync over async")]
         public override void WriteFile(string filename) { throw new System.PlatformNotSupportedException("Only support when running on ASP.NET Core or System.Web");}
     }
     public sealed partial class HttpRuntime

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpResponseTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpResponseTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using AutoFixture;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
@@ -418,21 +419,46 @@ public class HttpResponseTests
     }
 
     [Fact]
-    public void WriteFile()
+    [Obsolete(System.Web.Constants.ApiFromAspNet)]
+    public Task WriteFile()
         => SendFileTest((response, file) => response.WriteFile(file));
 
     [Fact]
-    public void TransmitFile()
+    public Task WriteFileAsync()
+        => SendFileTestAsync((response, file, token) => response.WriteFileAsync(file, token));
+
+    [Fact]
+    [Obsolete(System.Web.Constants.ApiFromAspNet)]
+    public Task TransmitFile()
         => SendFileTest((response, file) => response.TransmitFile(file));
 
     [Fact]
-    public void TransmitFileArgs()
+    public Task TransmitFileAsync()
+        => SendFileTestAsync((response, file, token) => response.TransmitFileAsync(file, token));
+
+    [Fact]
+    [Obsolete(System.Web.Constants.ApiFromAspNet)]
+    public Task TransmitFileArgs()
         => SendFileTest((response, file, offset, length) => response.TransmitFile(file, offset, length!.Value), 30, 3);
 
-    private static void SendFileTest(Action<HttpResponse, string> action)
+    [Fact]
+    public Task TransmitFileArgsAsync()
+        => SendFileTestAsync((response, file, offset, length, token) => response.TransmitFileAsync(file, offset, length!.Value, token), 30, 3, hasToken: true);
+
+    private static Task SendFileTest(Action<HttpResponse, string> action)
         => SendFileTest((response, file, offset, length) => action(response, file), 0, default);
 
-    private static void SendFileTest(Action<HttpResponse, string, long, long?> action, long offset, long? length)
+    private static Task SendFileTestAsync(Func<HttpResponse, string, CancellationToken, Task> func)
+        => SendFileTestAsync((response, file, offset, length, token) => func(response, file, token), 0, default, hasToken: true);
+
+    private static Task SendFileTest(Action<HttpResponse, string, long, long?> action, long offset, long? length)
+        => SendFileTestAsync((response, file, offset, length, _) =>
+        {
+            action(response, file, offset, length);
+            return Task.CompletedTask;
+        }, offset, length, hasToken: false);
+
+    private static async Task SendFileTestAsync(Func<HttpResponse, string, long, long?, CancellationToken, Task> func, long offset, long? length, bool hasToken)
     {
         // Arrange
         const string FileName = "somefile.txt";
@@ -449,12 +475,15 @@ public class HttpResponseTests
         responseCore.Setup(r => r.HttpContext).Returns(context.Object);
 
         var response = new HttpResponse(responseCore.Object);
+        using var cts = new CancellationTokenSource();
+
+        var token = hasToken ? cts.Token : default;
 
         // Act
-        action(response, FileName, offset, length);
+        await func(response, FileName, offset, length, token);
 
         // Assert
-        responsebody.Verify(r => r.SendFileAsync(FileName, offset, length, default), Times.Once);
+        responsebody.Verify(r => r.SendFileAsync(FileName, offset, length, token), Times.Once);
     }
 
     [InlineData(200, false)]

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpResponseTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpResponseTests.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Web;
 using AutoFixture;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;


### PR DESCRIPTION
This allows code to transition to a pure-async model instead of invoking sync over async.
