### PR TITLE
Add MVC filter to remove result if End() was called

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/IHttpRequestAdapterFeature.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/IHttpRequestAdapterFeature.cs
@@ -1,17 +1,17 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.IO;
+using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.SystemWebAdapters;
 
-internal interface IBufferedResponseFeature
+internal interface IHttpRequestAdapterFeature
 {
-    Stream Stream { get; }
+    bool IsEnded { get; }
 
     bool SuppressContent { get; set; }
 
-    void End();
+    Task EndAsync();
 
     void ClearContent();
 }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/Mvc/MvcExtensions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/Mvc/MvcExtensions.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.SystemWebAdapters;
+using Microsoft.AspNetCore.SystemWebAdapters.Mvc;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+internal static class MvcExtensions
+{
+    public static ISystemWebAdapterBuilder AddMvc(this ISystemWebAdapterBuilder builder)
+    {
+        builder.Services.AddTransient<ResponseEndFilter>();
+
+        builder.Services.AddOptions<MvcOptions>()
+            .Configure(options =>
+            {
+                // We want the check for HttpResponse.End() to be done as soon as possible after the action is run.
+                // This will minimize any chance that output will be written which will fail since the response has completed.
+                options.Filters.Add<ResponseEndFilter>(int.MaxValue);
+            });
+
+        return builder;
+    }
+}

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/Mvc/ResponseEndFilter.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/Mvc/ResponseEndFilter.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.SystemWebAdapters.Mvc;
+
+internal partial class ResponseEndFilter : IActionFilter
+{
+    private readonly ILogger<ResponseEndFilter> _logger;
+
+    [LoggerMessage(0, LogLevel.Trace, "Clearing MVC result since HttpResponse.End() was called")]
+    private partial void LogClearingResult();
+
+    public ResponseEndFilter(ILogger<ResponseEndFilter> logger)
+    {
+        _logger = logger;
+    }
+
+    public void OnActionExecuted(ActionExecutedContext context)
+    {
+        if (context.Result is not null && context.HttpContext.Features.Get<IHttpRequestAdapterFeature>() is { IsEnded: true })
+        {
+            LogClearingResult();
+            context.Result = null;
+        }
+    }
+
+    public void OnActionExecuting(ActionExecutingContext context)
+    {
+    }
+}

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/SystemWebAdaptersExtensions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/SystemWebAdaptersExtensions.cs
@@ -6,7 +6,9 @@ using System.Web.Caching;
 using System.Web.Configuration;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.SystemWebAdapters;
+using Microsoft.AspNetCore.SystemWebAdapters.Mvc;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -19,7 +21,8 @@ public static class SystemWebAdaptersExtensions
         services.AddSingleton<BrowserCapabilitiesFactory>();
         services.AddTransient<IStartupFilter, HttpContextStartupFilter>();
 
-        return new SystemWebAdapterBuilder(services);
+        return new SystemWebAdapterBuilder(services)
+            .AddMvc();
     }
 
     public static void UseSystemWebAdapters(this IApplicationBuilder app)

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponse.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponse.cs
@@ -25,7 +25,7 @@ namespace System.Web
 
         private NameValueCollection? _headers;
         private ResponseHeaders? _typedHeaders;
-        private IBufferedResponseFeature? _bufferedFeature;
+        private IHttpRequestAdapterFeature? _adapterFeature;
         private TextWriter? _writer;
         private HttpCookieCollection? _cookies;
 
@@ -34,8 +34,8 @@ namespace System.Web
             _response = response;
         }
 
-        private IBufferedResponseFeature BufferedFeature => _bufferedFeature ??= _response.HttpContext.Features.Get<IBufferedResponseFeature>()
-            ?? throw new InvalidOperationException("Response buffering must be enabled on this endpoint for this feature via the IBufferResponseStreamMetadata metadata item");
+        private IHttpRequestAdapterFeature AdapterFeature => _adapterFeature ??= _response.HttpContext.Features.Get<IHttpRequestAdapterFeature>()
+            ?? throw new InvalidOperationException($"Response buffering must be enabled on this endpoint for this API via the {nameof(BufferResponseStreamAttribute)} metadata item");
 
         internal ResponseHeaders TypedHeaders => _typedHeaders ??= new(_response.Headers);
 
@@ -82,8 +82,8 @@ namespace System.Web
 
         public bool SuppressContent
         {
-            get => BufferedFeature.SuppressContent;
-            set => BufferedFeature.SuppressContent = value;
+            get => AdapterFeature.SuppressContent;
+            set => AdapterFeature.SuppressContent = value;
         }
 
         public Encoding ContentEncoding
@@ -201,7 +201,7 @@ namespace System.Web
 
         public void SetCookie(HttpCookie cookie) => Cookies.Set(cookie);
 
-        public void End() => BufferedFeature.End();
+        public void End() => AdapterFeature.EndAsync().GetAwaiter().GetResult();
 
         public void Write(char ch) => Output.Write(ch);
 
@@ -233,7 +233,7 @@ namespace System.Web
             }
             else
             {
-                BufferedFeature.ClearContent();
+                AdapterFeature.ClearContent();
             }
         }
 

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpResponseTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpResponseTests.cs
@@ -106,11 +106,11 @@ public class HttpResponseTests
     public void SuppressContent(bool suppressContent)
     {
         // Arrange
-        var feature = new Mock<IBufferedResponseFeature>();
+        var feature = new Mock<IHttpRequestAdapterFeature>();
         feature.SetupProperty(f => f.SuppressContent);
 
         var features = new Mock<IFeatureCollection>();
-        features.Setup(f => f.Get<IBufferedResponseFeature>()).Returns(feature.Object);
+        features.Setup(f => f.Get<IHttpRequestAdapterFeature>()).Returns(feature.Object);
 
         var context = new Mock<HttpContextCore>();
         context.Setup(c => c.Features).Returns(features.Object);
@@ -133,10 +133,10 @@ public class HttpResponseTests
     public void End()
     {
         // Arrange
-        var feature = new Mock<IBufferedResponseFeature>();
+        var feature = new Mock<IHttpRequestAdapterFeature>();
 
         var features = new Mock<IFeatureCollection>();
-        features.Setup(f => f.Get<IBufferedResponseFeature>()).Returns(feature.Object);
+        features.Setup(f => f.Get<IHttpRequestAdapterFeature>()).Returns(feature.Object);
 
         var context = new Mock<HttpContextCore>();
         context.Setup(c => c.Features).Returns(features.Object);
@@ -151,7 +151,7 @@ public class HttpResponseTests
         response.End();
 
         // Assert
-        feature.Verify(f => f.End(), Times.Once);
+        feature.Verify(f => f.EndAsync(), Times.Once);
     }
 
     [Fact]
@@ -258,11 +258,11 @@ public class HttpResponseTests
             { HeaderNames.ContentType, "application/json" },
         };
 
-        var feature = new Mock<IBufferedResponseFeature>();
+        var feature = new Mock<IHttpRequestAdapterFeature>();
         var responseFeature = new Mock<IHttpResponseFeature>();
 
         var features = new Mock<IFeatureCollection>();
-        features.Setup(f => f.Get<IBufferedResponseFeature>()).Returns(feature.Object);
+        features.Setup(f => f.Get<IHttpRequestAdapterFeature>()).Returns(feature.Object);
         features.Setup(f => f.Get<IHttpResponseFeature>()).Returns(responseFeature.Object);
 
         var body = new Mock<Stream>();
@@ -290,11 +290,11 @@ public class HttpResponseTests
     public void ClearContentsStreamNotSeekable()
     {
         // Arrange
-        var feature = new Mock<IBufferedResponseFeature>();
+        var feature = new Mock<IHttpRequestAdapterFeature>();
         var body = new Mock<Stream>();
 
         var features = new Mock<IFeatureCollection>();
-        features.Setup(f => f.Get<IBufferedResponseFeature>()).Returns(feature.Object);
+        features.Setup(f => f.Get<IHttpRequestAdapterFeature>()).Returns(feature.Object);
 
         var context = new Mock<HttpContextCore>();
         context.Setup(c => c.Features).Returns(features.Object);
@@ -490,7 +490,7 @@ public class HttpResponseTests
         var url = _fixture.Create<string>();
         var features = new FeatureCollection();
 
-        var bufferedBody = new Mock<IBufferedResponseFeature>();
+        var bufferedBody = new Mock<IHttpRequestAdapterFeature>();
         bufferedBody.SetupAllProperties();
         features.Set(bufferedBody.Object);
 
@@ -515,6 +515,6 @@ public class HttpResponseTests
 
         // Assert
         responseCore.Verify(r => r.Redirect(url, true), Times.Once);
-        bufferedBody.Verify(b => b.End(), isEndCalled ? Times.Once : Times.Never);
+        bufferedBody.Verify(b => b.EndAsync(), isEndCalled ? Times.Once : Times.Never);
     }
 }


### PR DESCRIPTION
On ASP.NET Framework, HttpResponse.End() would flush everything and terminate the pipeline at the next available moment (sometimes it would raise a ThreadAbortException, but not always). To mimic this, we can add an MVC filter that will remove any result that may have been added so that the MVC pipeline will not attempt to write anything.

Fixes #111
