### PR TITLE
Rework configuring timeout on remote app API

### DIFF
--- a/Microsoft.AspNetCore.SystemWebAdapters.sln
+++ b/Microsoft.AspNetCore.SystemWebAdapters.sln
@@ -16,6 +16,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
+		global.json = global.json
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/samples/MvcApp/MvcApp.csproj
+++ b/samples/MvcApp/MvcApp.csproj
@@ -184,8 +184,8 @@
       <HintPath>..\..\packages\System.Security.Principal.Windows.5.0.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
     </Reference>
     <Reference Include="System.ServiceProcess" />
-    <Reference Include="System.Text.Encodings.Web, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Text.Encodings.Web.4.5.0\lib\netstandard2.0\System.Text.Encodings.Web.dll</HintPath>
+    <Reference Include="System.Text.Encodings.Web, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Text.Encodings.Web.6.0.0\lib\netstandard2.0\System.Text.Encodings.Web.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/samples/MvcApp/Web.config
+++ b/samples/MvcApp/Web.config
@@ -35,6 +35,14 @@
   </system.web>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+	  <dependentAssembly>
+		  <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+		  <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		  <assemblyIdentity name="System.Buffers" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+		  <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
+	  </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.ComponentModel.Annotations" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0" />

--- a/samples/MvcApp/packages.config
+++ b/samples/MvcApp/packages.config
@@ -56,7 +56,7 @@
   <package id="System.Security.Cryptography.Xml" version="6.0.0" targetFramework="net472" />
   <package id="System.Security.Permissions" version="4.5.0" targetFramework="net472" />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net472" />
-  <package id="System.Text.Encodings.Web" version="4.5.0" targetFramework="net472" />
+  <package id="System.Text.Encodings.Web" version="6.0.0" targetFramework="net472" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
   <package id="WebGrease" version="1.6.0" targetFramework="net472" />

--- a/samples/RemoteAuth/Forms/FormsAuth/FormsAuth.csproj
+++ b/samples/RemoteAuth/Forms/FormsAuth/FormsAuth.csproj
@@ -72,12 +72,6 @@
       <Private>True</Private>
       <HintPath>..\..\..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
-    <Reference Include="AspNet.ScriptManager.bootstrap">
-      <HintPath>..\..\..\..\packages\AspNet.ScriptManager.bootstrap.3.4.1\lib\net45\AspNet.ScriptManager.bootstrap.dll</HintPath>
-    </Reference>
-    <Reference Include="AspNet.ScriptManager.jQuery">
-      <HintPath>..\..\..\..\packages\AspNet.ScriptManager.jQuery.3.4.1\lib\net45\AspNet.ScriptManager.jQuery.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.ScriptManager.MSAjax">
       <HintPath>..\..\..\..\packages\Microsoft.AspNet.ScriptManager.MSAjax.5.0.0\lib\net45\Microsoft.ScriptManager.MSAjax.dll</HintPath>
     </Reference>

--- a/samples/RemoteAuth/Forms/FormsAuth/packages.config
+++ b/samples/RemoteAuth/Forms/FormsAuth/packages.config
@@ -1,8 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.5.0.2" targetFramework="net472" />
-  <package id="AspNet.ScriptManager.bootstrap" version="3.4.1" targetFramework="net472" />
-  <package id="AspNet.ScriptManager.jQuery" version="3.4.1" targetFramework="net472" />
   <package id="bootstrap" version="3.4.1" targetFramework="net472" />
   <package id="jQuery" version="3.4.1" targetFramework="net472" />
   <package id="Microsoft.AspNet.FriendlyUrls" version="1.0.2" targetFramework="net472" />

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/RemoteSession/RemoteAppSessionStateClientOptions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/RemoteSession/RemoteAppSessionStateClientOptions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel.DataAnnotations;
-using System;
 
 namespace Microsoft.AspNetCore.SystemWebAdapters.SessionState.RemoteSession;
 
@@ -16,11 +15,4 @@ public class RemoteAppSessionStateClientOptions
     /// </summary>
     [Required]
     public string CookieName { get; set; } = SessionConstants.DefaultCookieName;
-
-    /// <summary>
-    /// The maximum time loading session state from the remote app
-    /// or committing changes to it can take before timing out.
-    /// </summary>
-    [Required]
-    public TimeSpan NetworkTimeout { get; set; } = TimeSpan.FromMinutes(1);
 }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/RemoteSession/RemoteAppSessionStateExtensions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/RemoteSession/RemoteAppSessionStateExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Net.Http;
 using Microsoft.AspNetCore.SystemWebAdapters;
+using Microsoft.AspNetCore.SystemWebAdapters.SessionState;
 using Microsoft.AspNetCore.SystemWebAdapters.SessionState.RemoteSession;
 
 namespace Microsoft.Extensions.DependencyInjection;
@@ -17,9 +18,12 @@ public static class RemoteAppSessionStateExtensions
             throw new ArgumentNullException(nameof(builder));
         }
 
-        builder.Services.AddHttpClient<ISessionManager, RemoteAppSessionStateManager>()
+        builder.Services.AddHttpClient(SessionConstants.SessionClientName)
             // Disable cookies in the HTTP client because the service will manage the cookie header directly
             .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler { UseCookies = false });
+
+        builder.Services.AddTransient<ISessionManager, RemoteAppSessionStateManager>();
+
         builder.Services.AddOptions<RemoteAppSessionStateClientOptions>()
             .Configure(configure ?? (_ => { }))
             .ValidateDataAnnotations();

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/RemoteSession/RemoteAppSessionStateManager.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/RemoteSession/RemoteAppSessionStateManager.cs
@@ -37,7 +37,7 @@ internal partial class RemoteAppSessionStateManager : ISessionManager
         // Use the HttpClient supplied in options if one is present;
         // otherwise, generate a client with an IHttpClientFactory from DI
         _client = remoteOptions.BackchannelHttpClient ?? httpClientFactory?.CreateClient(SessionConstants.SessionClientName) ?? throw new ArgumentNullException(nameof(httpClientFactory));
-        _client.BaseAddress = new Uri(remoteOptions.RemoteAppUrl, _options.SessionEndpointPath);
+        _client.BaseAddress = new Uri($"{remoteOptions.RemoteAppUrl.ToString().TrimEnd('/')}{_options.SessionEndpointPath}");
         _client.DefaultRequestHeaders.Add(remoteOptions.ApiKeyHeader, remoteOptions.ApiKey);
     }
 

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/SessionConstants.Shared.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.SessionState/SessionConstants.Shared.cs
@@ -5,6 +5,8 @@ namespace Microsoft.AspNetCore.SystemWebAdapters.SessionState;
 
 internal static class SessionConstants
 {
+    internal const string SessionClientName = "RemoteSessionHttpClient";
+
     public const string ReadOnlyHeaderName = "X-SystemWebAdapter-RemoteAppSession-ReadOnly";
 
     public const string SessionEndpointPath = "/systemweb-adapters/session";

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/Authentication/AuthenticationConstants.Shared.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/Authentication/AuthenticationConstants.Shared.cs
@@ -5,6 +5,8 @@ namespace Microsoft.AspNetCore.SystemWebAdapters.Authentication;
 
 internal static class AuthenticationConstants
 {
+    internal const string AuthClientName = "RemoteAuthHttpClient";
+
     public const string ForwardedHostHeaderName = "x-forwarded-host";
     public const string ForwardedProtoHeaderName = "x-forwarded-proto";
     public const string MigrationAuthenticateRequestHeaderName = "x-migration-authenticate";

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/Authentication/RemoteAppAuthenticationClientOptions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/Authentication/RemoteAppAuthenticationClientOptions.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.DataAnnotations;
@@ -36,13 +35,6 @@ public class RemoteAppAuthenticationClientOptions : AuthenticationSchemeOptions
     /// are specified, all headers will be forwarded.
     /// </summary>
     public ICollection<string> ResponseHeadersToForward { get; } = new HashSet<string>(DefaultResponseHeadersToForward);
-
-    /// <summary>
-    /// The maximum time loading session state from the remote app
-    /// or committing changes to it can take before timing out.
-    /// </summary>
-    [Required]
-    public TimeSpan NetworkTimeout { get; set; } = TimeSpan.FromMinutes(1);
 
     /// <summary>
     /// Gets or sets the endpoint on the remote app that provides remote authentication

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/Authentication/RemoteAppAuthenticationExtensions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/Authentication/RemoteAppAuthenticationExtensions.cs
@@ -57,10 +57,10 @@ public static class RemoteAppAuthenticationExtensions
 
         authenticationBuilder.Services.AddScoped<IRemoteAppAuthenticationResultProcessor, RedirectUrlProcessor>();
         authenticationBuilder.Services.AddSingleton<IAuthenticationResultFactory, RemoteAppAuthenticationResultFactory>();
-        authenticationBuilder.Services.AddHttpClient<IRemoteAppAuthenticationService, RemoteAppAuthenticationService>()
+        authenticationBuilder.Services.AddHttpClient(AuthenticationConstants.AuthClientName)
             // Disable cookies in the HTTP client because the service will manage the cookie header directly
             .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler { UseCookies = false, AllowAutoRedirect = false });
-
+        authenticationBuilder.Services.AddTransient<IRemoteAppAuthenticationService, RemoteAppAuthenticationService>();
         authenticationBuilder.Services.AddOptions<RemoteAppAuthenticationClientOptions>(scheme)
             .Configure(configureOptions ?? (_ => { }))
             .ValidateDataAnnotations();

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/Authentication/RemoteAppAuthenticationService.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/Authentication/RemoteAppAuthenticationService.cs
@@ -29,17 +29,20 @@ internal partial class RemoteAppAuthenticationService : IRemoteAppAuthentication
     private RemoteAppAuthenticationClientOptions? _options;
 
     public RemoteAppAuthenticationService(
-        HttpClient client,
+        IHttpClientFactory httpClientFactory,
         IAuthenticationResultFactory resultFactory,
         IOptionsSnapshot<RemoteAppAuthenticationClientOptions> authOptions,
         IOptions<RemoteAppOptions> remoteAppOptions,
         ILogger<RemoteAppAuthenticationService> logger)
     {
-        _client = client ?? throw new ArgumentNullException(nameof(client));
+        _remoteAppOptions = remoteAppOptions?.Value ?? throw new ArgumentNullException(nameof(remoteAppOptions));
         _resultFactory = resultFactory ?? throw new ArgumentNullException(nameof(resultFactory));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _remoteAppOptions = remoteAppOptions?.Value ?? throw new ArgumentNullException(nameof(remoteAppOptions));
         _authOptionsSnapshot = authOptions ?? throw new ArgumentNullException(nameof(authOptions));
+
+        // Use the HttpClient supplied in options if one is present;
+        // otherwise, generate a client with an IHttpClientFactory from DI
+        _client = _remoteAppOptions.BackchannelHttpClient ?? httpClientFactory?.CreateClient(AuthenticationConstants.AuthClientName) ?? throw new ArgumentNullException(nameof(httpClientFactory));
     }
 
     /// <summary>

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/Authentication/RemoteAppAuthenticationService.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/Authentication/RemoteAppAuthenticationService.cs
@@ -54,7 +54,7 @@ internal partial class RemoteAppAuthenticationService : IRemoteAppAuthentication
         // Finish initializing the http client here since the scheme won't be known
         // until the owning authentication handler is initialized.
         _options = _authOptionsSnapshot.Get(scheme.Name);
-        _client.BaseAddress = new Uri(_remoteAppOptions.RemoteAppUrl, _options.AuthenticationEndpointPath);
+        _client.BaseAddress = new Uri($"{_remoteAppOptions.RemoteAppUrl.ToString().TrimEnd('/')}{_options.AuthenticationEndpointPath}");
         _client.DefaultRequestHeaders.Add(_remoteAppOptions.ApiKeyHeader, _remoteAppOptions.ApiKey);
 
         return Task.CompletedTask;

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/RemoteAppOptions.Shared.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/RemoteAppOptions.Shared.cs
@@ -4,6 +4,7 @@
 using System;
 #if NET6_0_OR_GREATER
 using System.ComponentModel.DataAnnotations;
+using System.Net.Http;
 #endif
 
 namespace Microsoft.AspNetCore.SystemWebAdapters;
@@ -37,5 +38,11 @@ public class RemoteAppOptions
     /// </summary>
     [Required]
     public Uri RemoteAppUrl { get; set; } = null!;
+
+    /// <summary>
+    /// Gets or sets an HttpClient to use for making requests to the remote app.
+    /// A new HttpClient will be automatically generated if none is provided.
+    /// </summary>
+    public HttpClient? BackchannelHttpClient { get; set; }
 #endif
 }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/RemoteAppOptions.Shared.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/RemoteAppOptions.Shared.cs
@@ -40,8 +40,8 @@ public class RemoteAppOptions
     public Uri RemoteAppUrl { get; set; } = null!;
 
     /// <summary>
-    /// Gets or sets an HttpClient to use for making requests to the remote app.
-    /// A new HttpClient will be automatically generated if none is provided.
+    /// Gets or sets an <see cref="HttpClient"/> to use for making requests to the remote app.
+    /// A new <see cref="HttpClient"/> will be automatically generated if none is provided.
     /// </summary>
     public HttpClient? BackchannelHttpClient { get; set; }
 #endif


### PR DESCRIPTION
Replaced `NetworkTimeout` with the ability to just provide an `HttpClient` as per API review. Also fixed an issue with paths on  configured base URLs getting dropped.

Fixes #133 
Fixes #138