### PR TITLE
implicit cast operators for HttpContextBase, HttpRequestBase, HttpResponseBase

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpRequestBase.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpRequestBase.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Specialized;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Security.Principal;
 using System.Text;
+using Microsoft.AspNetCore.SystemWebAdapters;
 
 namespace System.Web
 {
@@ -79,5 +81,8 @@ namespace System.Web
         public virtual byte[] BinaryRead(int count) => throw new NotImplementedException();
 
         public virtual void Abort() => throw new NotImplementedException();
+
+        [return: NotNullIfNotNull("request")]
+        public static implicit operator HttpRequestBase?(HttpRequestCore? request) => request?.GetAdapterBase();
     }
 }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponseBase.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponseBase.cs
@@ -5,6 +5,7 @@ using System.Collections.Specialized;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
+using Microsoft.AspNetCore.SystemWebAdapters;
 
 namespace System.Web
 {
@@ -108,5 +109,8 @@ namespace System.Web
         public virtual void TransmitFile(string filename) => throw new NotImplementedException();
 
         public virtual void TransmitFile(string filename, long offset, long length) => throw new NotImplementedException();
+
+        [return: NotNullIfNotNull("response")]
+        public static implicit operator HttpResponseBase?(HttpResponseCore? response) => response?.GetAdapterBase();
     }
 }


### PR DESCRIPTION
Issue https://github.com/dotnet/systemweb-adapters/issues/142

Add implicit cast operators for HttpContextBase, HttpRequestBase, HttpResponseBase from and to the equivalent ASP.NET Core types.