### PR TITLE
Use reflection to set host header when forwarding

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices/ProxyHeaderModule.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices/ProxyHeaderModule.cs
@@ -117,14 +117,13 @@ internal class ProxyHeaderModule : IHttpModule
     private class ReflectionHelper
     {
         private readonly FieldInfo _wrField;
-        private readonly Type _iis7WorkerRequestType;
         private readonly FieldInfo _knownRequestHeadersField;
 
         public ReflectionHelper()
         {
             _wrField = typeof(HttpRequest).GetField("_wr", BindingFlags.NonPublic | BindingFlags.Instance);
-            _iis7WorkerRequestType = Assembly.GetAssembly(typeof(HttpRequest)).GetType("System.Web.Hosting.IIS7WorkerRequest");
-            _knownRequestHeadersField = _iis7WorkerRequestType.GetField("_knownRequestHeaders", BindingFlags.NonPublic | BindingFlags.Instance);
+            var type = Assembly.GetAssembly(typeof(HttpRequest)).GetType("System.Web.Hosting.IIS7WorkerRequest");
+            _knownRequestHeadersField = type.GetField("_knownRequestHeaders", BindingFlags.NonPublic | BindingFlags.Instance);
         }
         
         public void SetHostHeader(HttpRequest request, string host)

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices/ProxyHeaderModule.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices/ProxyHeaderModule.cs
@@ -126,6 +126,7 @@ internal class ProxyHeaderModule : IHttpModule
             _iis7WorkerRequestType = Assembly.GetAssembly(typeof(HttpRequest)).GetType("System.Web.Hosting.IIS7WorkerRequest");
             _knownRequestHeadersField = _iis7WorkerRequestType.GetField("_knownRequestHeaders", BindingFlags.NonPublic | BindingFlags.Instance);
         }
+        
         public void SetHostHeader(HttpRequest request, string host)
         {
             // Need to use reflection to force HttpRequest to update the known headers


### PR DESCRIPTION
Fixes https://github.com/dotnet/systemweb-adapters/issues/156

Verified in debugger that the reflection codepath is not hit on normal requests to framework app, but is hit and updates the url correctly in the coreapp:

![image](https://user-images.githubusercontent.com/6537861/186769650-15620045-c8f0-4408-b25e-e17d7d8bae0b.png)
