### PR TITLE
Use latest build VMs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -119,7 +119,7 @@ stages:
 
       - job: macOS
         pool:
-          vmImage: macOS-10.15
+          vmImage: macOS-latest
         strategy:
           matrix:
             release:
@@ -155,7 +155,7 @@ stages:
 
       - job: Linux
         pool:
-          vmImage: ubuntu-18.04
+          vmImage: ubuntu-latest
           container: LinuxContainer
         strategy:
           matrix:


### PR DESCRIPTION
There were warnings showing up for the current vm images we're using for
builds, and would sometimes fail to encourage people to update to the latest
images. This updates the script to use the latest images.
