### PR TITLE
Add recommended virtual directory setup to docs

### DIFF
--- a/docs/usage_guidance.md
+++ b/docs/usage_guidance.md
@@ -99,4 +99,4 @@ The [remote session support](session-state/remote-session.md) exposes an endpoin
 
 The virtual directory setup is used for route generation, authorization, and other services within the system. At this point, no reliable method has been found to enable different virtual directories due to how ASP.NET Framework works.
 
-**Recomendation**: Ensure your two applications have the same virtual directory 
+**Recomendation**: If you are using virtual directories, ensure your two applications are on different sites with the same application/virtual directory layout.

--- a/docs/usage_guidance.md
+++ b/docs/usage_guidance.md
@@ -95,3 +95,8 @@ The [remote session support](session-state/remote-session.md) exposes an endpoin
 
 **Recommendation**: Ensure the API key used is a strong one and that the connection with the framework app is done over SSL.
 
+## Virtual directories must be identical for framework and core applications
+
+The virtual directory setup is used for route generation, authorization, and other services within the system. At this point, no reliable method has been found to enable different virtual directories due to how ASP.NET Framework works.
+
+**Recomendation**: Ensure your two applications have the same virtual directory 


### PR DESCRIPTION
Virtual directories must be the same between the core and framework app. This may not be obvious to users as they get started, but a number of issues have been filed around this. This change adds some docs to guide people to this.

Fixes #174
