### PR TITLE
Use a shared client for remote app connections

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Authentication/RemoteAppAuthenticationExtensions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Authentication/RemoteAppAuthenticationExtensions.cs
@@ -57,9 +57,6 @@ public static class RemoteAppAuthenticationExtensions
 
         authenticationBuilder.Services.AddScoped<IRemoteAppAuthenticationResultProcessor, RedirectUrlProcessor>();
         authenticationBuilder.Services.AddSingleton<IAuthenticationResultFactory, RemoteAppAuthenticationResultFactory>();
-        authenticationBuilder.Services.AddHttpClient(AuthenticationConstants.AuthClientName)
-            // Disable cookies in the HTTP client because the service will manage the cookie header directly
-            .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler { UseCookies = false, AllowAutoRedirect = false });
         authenticationBuilder.Services.AddTransient<IRemoteAppAuthenticationService, RemoteAppAuthenticationService>();
         authenticationBuilder.Services.AddOptions<RemoteAppAuthenticationClientOptions>(scheme)
             .Configure(configureOptions ?? (_ => { }))

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/RemoteAppClientOptions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/RemoteAppClientOptions.cs
@@ -31,8 +31,7 @@ public class RemoteAppClientOptions
     public Uri RemoteAppUrl { get; set; } = null!;
 
     /// <summary>
-    /// Gets or sets an <see cref="HttpClient"/> to use for making requests to the remote app.
-    /// A new <see cref="HttpClient"/> will be automatically generated if none is provided.
+    /// Gets or sets an <see cref="HttpMessageHandler"/> to use for making requests to the remote app.
     /// </summary>
-    public HttpClient? BackchannelHttpClient { get; set; }
+    public HttpMessageHandler? BackchannelHandler { get; set; }
 }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/SessionState/RemoteSession/RemoteAppSessionStateExtensions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/SessionState/RemoteSession/RemoteAppSessionStateExtensions.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Net.Http;
 using Microsoft.AspNetCore.SystemWebAdapters;
-using Microsoft.AspNetCore.SystemWebAdapters.SessionState;
 using Microsoft.AspNetCore.SystemWebAdapters.SessionState.RemoteSession;
 
 namespace Microsoft.Extensions.DependencyInjection;
@@ -17,10 +15,6 @@ public static class RemoteAppSessionStateExtensions
         {
             throw new ArgumentNullException(nameof(builder));
         }
-
-        builder.Services.AddHttpClient(SessionConstants.SessionClientName)
-            // Disable cookies in the HTTP client because the service will manage the cookie header directly
-            .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler { UseCookies = false });
 
         builder.Services.AddTransient<ISessionManager, RemoteAppSessionStateManager>();
 

--- a/src/Services/Authentication/AuthenticationConstants.cs
+++ b/src/Services/Authentication/AuthenticationConstants.cs
@@ -5,8 +5,6 @@ namespace Microsoft.AspNetCore.SystemWebAdapters.Authentication;
 
 internal static class AuthenticationConstants
 {
-    internal const string AuthClientName = "RemoteAuthHttpClient";
-
     public const string ForwardedHostHeaderName = "x-forwarded-host";
     public const string ForwardedProtoHeaderName = "x-forwarded-proto";
     public const string MigrationAuthenticateRequestHeaderName = "x-migration-authenticate";

--- a/src/Services/RemoteConstants.cs
+++ b/src/Services/RemoteConstants.cs
@@ -6,4 +6,6 @@ namespace Microsoft.AspNetCore.SystemWebAdapters;
 internal static class RemoteConstants
 {
     internal const string ApiKeyHeaderName = "X-SystemWebAdapter-RemoteAppAuthentication-Key";
+
+    internal const string HttpClientName = "remote-client";
 }

--- a/src/Services/SessionState/SessionConstants.cs
+++ b/src/Services/SessionState/SessionConstants.cs
@@ -5,8 +5,6 @@ namespace Microsoft.AspNetCore.SystemWebAdapters.SessionState;
 
 internal static class SessionConstants
 {
-    internal const string SessionClientName = "RemoteSessionHttpClient";
-
     public const string ReadOnlyHeaderName = "X-SystemWebAdapter-RemoteAppSession-ReadOnly";
 
     public const string SessionEndpointPath = "/systemweb-adapters/session";


### PR DESCRIPTION
This change brings the configuration of the HttpClient into a shared
location for all the remote app connections. Now, any system that needs
to connect to the remote app can do so by just retrieving the client via
the IHttpClientFactory by name and the path/URI/backchannel will be
configured for them.
