### PR TITLE
Remove APIs that are not implemented

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Constants.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Constants.cs
@@ -5,7 +5,5 @@ namespace System.Web;
 
 internal static class Constants
 {
-    internal const string NotImplemented = "Not implemented yet for ASP.NET Core";
-
     internal const string ApiFromAspNet = "API is required to be the same as ASP.NET Framework";
 }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
@@ -367,8 +367,6 @@ namespace System.Web
         public string MachineName { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public void ClearError() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public System.Exception GetLastError() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
-        [System.ObsoleteAttribute("Not implemented yet for ASP.NET Core")]
-        public string MapPath(string path) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public static byte[] UrlTokenDecode(string input) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public static string UrlTokenEncode(byte[] input) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
     }
@@ -378,8 +376,6 @@ namespace System.Web
         public virtual string MachineName { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual void ClearError() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public virtual System.Exception GetLastError() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
-        [System.ObsoleteAttribute("Not implemented yet for ASP.NET Core")]
-        public virtual string MapPath(string path) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public virtual byte[] UrlTokenDecode(string input) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public virtual string UrlTokenEncode(byte[] input) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
     }
@@ -389,8 +385,6 @@ namespace System.Web
         public override string MachineName { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override void ClearError() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public override System.Exception GetLastError() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
-        [System.ObsoleteAttribute("Not implemented yet for ASP.NET Core")]
-        public override string MapPath(string path) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public override byte[] UrlTokenDecode(string input) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public override string UrlTokenEncode(byte[] input) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
     }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpServerUtility.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpServerUtility.cs
@@ -17,9 +17,6 @@ public class HttpServerUtility
 
     public string MachineName => Environment.MachineName;
 
-    [Obsolete(Constants.NotImplemented)]
-    public string MapPath(string path) => throw new NotImplementedException();
-
     [Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1024:Use properties where appropriate", Justification = Constants.ApiFromAspNet)]
     public Exception? GetLastError() => null;
 

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpServerUtilityBase.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpServerUtilityBase.cs
@@ -10,9 +10,6 @@ public class HttpServerUtilityBase
 {
     public virtual string MachineName => throw new NotImplementedException();
 
-    [Obsolete(Constants.NotImplemented)]
-    public virtual string MapPath(string path) => throw new NotImplementedException();
-
     public virtual Exception? GetLastError() => throw new NotImplementedException();
 
     public virtual byte[]? UrlTokenDecode(string input) => throw new NotImplementedException();

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpServerUtilityWrapper.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpServerUtilityWrapper.cs
@@ -18,9 +18,6 @@ public class HttpServerUtilityWrapper : HttpServerUtilityBase
 
     public override string MachineName => _utility.MachineName;
 
-    [Obsolete(Constants.NotImplemented)]
-    public override string MapPath(string path) => _utility.MapPath(path);
-
     public override byte[]? UrlTokenDecode(string input) => HttpServerUtility.UrlTokenDecode(input);
 
     public override string UrlTokenEncode(byte[] input) => HttpServerUtility.UrlTokenEncode(input);


### PR DESCRIPTION
This was a placeholder, but not planned for v1, so we should just remove it. If something is not implemented, it shouldn't be available.
