### PR TITLE
Implement MapPath and AppDomainAppPath

### DIFF
--- a/samples/ClassLibrary/RequestInfo.cs
+++ b/samples/ClassLibrary/RequestInfo.cs
@@ -15,6 +15,7 @@ public class RequestInfo
             writer.Write("VirtualDirectory", HttpRuntime.AppDomainAppVirtualPath);
             writer.Write("PhysicalDirectory", HttpRuntime.AppDomainAppPath);
             writer.Write("RequestDirectory", context.Server.MapPath(null));
+            writer.Write("RequestDirectory2", context.Server.MapPath(""));
             writer.Write("UploadedFiles", context.Server.MapPath("/UploadedFiles"));
             writer.Write("RelativeFiles", context.Server.MapPath("UploadedFiles"));
             writer.Write("AppFiles", context.Server.MapPath("~/MyUploadedFiles"));

--- a/samples/ClassLibrary/RequestInfo.cs
+++ b/samples/ClassLibrary/RequestInfo.cs
@@ -14,6 +14,7 @@ public class RequestInfo
         {
             writer.Write("VirtualDirectory", HttpRuntime.AppDomainAppVirtualPath);
             writer.Write("PhysicalDirectory", HttpRuntime.AppDomainAppPath);
+            writer.Write("RequestDirectory", context.Server.MapPath(null));
             writer.Write("UploadedFiles", context.Server.MapPath("/UploadedFiles"));
             writer.Write("RelativeFiles", context.Server.MapPath("UploadedFiles"));
             writer.Write("AppFiles", context.Server.MapPath("~/MyUploadedFiles"));

--- a/samples/ClassLibrary/RequestInfo.cs
+++ b/samples/ClassLibrary/RequestInfo.cs
@@ -13,6 +13,10 @@ public class RequestInfo
         using (var writer = new SimpleJsonWriter(context.Response))
         {
             writer.Write("VirtualDirectory", HttpRuntime.AppDomainAppVirtualPath);
+            writer.Write("PhysicalDirectory", HttpRuntime.AppDomainAppPath);
+            writer.Write("UploadedFiles", context.Server.MapPath("/UploadedFiles"));
+            writer.Write("RelativeFiles", context.Server.MapPath("UploadedFiles"));
+            writer.Write("AppFiles", context.Server.MapPath("~/MyUploadedFiles"));
             writer.Write("RequestVirtualDirectory", context.Request.ApplicationPath);
             writer.Write("RawUrl", context.Request.RawUrl);
             writer.Write("Path", context.Request.Path);

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpRuntimeFactory.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpRuntimeFactory.cs
@@ -24,7 +24,7 @@ internal static class HttpRuntimeFactory
     {
         public string AppDomainAppVirtualPath => "/";
 
-        public string AppDomainAppPath => AppDomain.CurrentDomain.BaseDirectory;
+        public string AppDomainAppPath => AppContext.BaseDirectory;
     }
 
     internal class IISHttpRuntime : IHttpRuntime

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpRuntimeFactory.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpRuntimeFactory.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using Microsoft.AspNetCore.SystemWebAdapters;
 
 namespace Microsoft.Extensions.DependencyInjection;
@@ -22,6 +23,8 @@ internal static class HttpRuntimeFactory
     internal class DefaultHttpRuntime : IHttpRuntime
     {
         public string AppDomainAppVirtualPath => "/";
+
+        public string AppDomainAppPath => AppDomain.CurrentDomain.BaseDirectory;
     }
 
     internal class IISHttpRuntime : IHttpRuntime
@@ -34,5 +37,7 @@ internal static class HttpRuntimeFactory
         }
 
         public string AppDomainAppVirtualPath => _config.pwzVirtualApplicationPath;
+
+        public string AppDomainAppPath => _config.pwzFullApplicationPath;
     }
 }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/IHttpRuntime.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/IHttpRuntime.cs
@@ -6,4 +6,5 @@ namespace Microsoft.AspNetCore.SystemWebAdapters;
 internal interface IHttpRuntime
 {
     string AppDomainAppVirtualPath { get; }
+    string AppDomainAppPath { get; }
 }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
@@ -378,7 +378,6 @@ namespace System.Web
         public virtual string MachineName { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual void ClearError() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public virtual System.Exception GetLastError() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
-        [System.ObsoleteAttribute("Not implemented yet for ASP.NET Core")]
         public virtual string MapPath(string path) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public virtual byte[] UrlTokenDecode(string input) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public virtual string UrlTokenEncode(byte[] input) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
@@ -359,7 +359,8 @@ namespace System.Web
     public sealed partial class HttpRuntime
     {
         internal HttpRuntime() { }
-        public static string AppDomainAppVirtualPath { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public static string AppDomainAppPath { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public static string AppDomainAppVirtualPath { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
     }
     public partial class HttpServerUtility
     {
@@ -367,7 +368,6 @@ namespace System.Web
         public string MachineName { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public void ClearError() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public System.Exception GetLastError() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
-        [System.ObsoleteAttribute("Not implemented yet for ASP.NET Core")]
         public string MapPath(string path) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public static byte[] UrlTokenDecode(string input) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public static string UrlTokenEncode(byte[] input) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
@@ -389,7 +389,6 @@ namespace System.Web
         public override string MachineName { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override void ClearError() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public override System.Exception GetLastError() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
-        [System.ObsoleteAttribute("Not implemented yet for ASP.NET Core")]
         public override string MapPath(string path) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public override byte[] UrlTokenDecode(string input) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public override string UrlTokenEncode(byte[] input) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
@@ -359,8 +359,8 @@ namespace System.Web
     public sealed partial class HttpRuntime
     {
         internal HttpRuntime() { }
-        public static string AppDomainAppPath { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
-        public static string AppDomainAppVirtualPath { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public static string AppDomainAppPath { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public static string AppDomainAppVirtualPath { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
     }
     public partial class HttpServerUtility
     {

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpRuntime.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpRuntime.cs
@@ -20,4 +20,5 @@ public sealed class HttpRuntime
     }
 
     public static string AppDomainAppVirtualPath => Current.AppDomainAppVirtualPath;
+	public static string AppDomainAppPath => Current.AppDomainAppPath;
 }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpServerUtility.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpServerUtility.cs
@@ -1,7 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace System.Web;
 
@@ -21,10 +23,14 @@ public class HttpServerUtility
     {
         var appPath = path is null ? VirtualPathUtility.GetDirectory(_context.Request.Path) :
             VirtualPathUtility.Combine(
-            VirtualPathUtility.GetDirectory(_context.Request.Path)
+            VirtualPathUtility.GetDirectory(_context.Request.Path) ?? "/"
             , path);
-        if (string.IsNullOrEmpty(appPath)) return HttpRuntime.AppDomainAppPath;
-        return System.IO.Path.Combine(HttpRuntime.AppDomainAppPath, appPath[1..].Replace('/', System.IO.Path.DirectorySeparatorChar));
+        // Potential alternative implementations here - for the most literal match to the original use HttpRuntime.AppDomainAppPath
+        var rootPath = HttpRuntime.AppDomainAppPath;
+        //var rootPath = _context.RequestServices.GetRequiredService<IWebHostEnvironment>().WebRootPath;
+        //var rootPath = _context.RequestServices.GetRequiredService<IWebHostEnvironment>().ContentRootPath;
+        if (string.IsNullOrEmpty(appPath)) return rootPath;
+        return System.IO.Path.Combine(rootPath, appPath[1..].Replace('/', System.IO.Path.DirectorySeparatorChar));
     }
 
     [Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1024:Use properties where appropriate", Justification = Constants.ApiFromAspNet)]

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpServerUtility.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpServerUtility.cs
@@ -17,8 +17,15 @@ public class HttpServerUtility
 
     public string MachineName => Environment.MachineName;
 
-    [Obsolete(Constants.NotImplemented)]
-    public string MapPath(string path) => throw new NotImplementedException();
+    public string MapPath(string? path)
+    {
+        var appPath = path is null ? VirtualPathUtility.GetDirectory(_context.Request.Path) :
+            VirtualPathUtility.Combine(
+            VirtualPathUtility.GetDirectory(_context.Request.Path)
+            , path);
+        if (string.IsNullOrEmpty(appPath)) return HttpRuntime.AppDomainAppPath;
+        return System.IO.Path.Combine(HttpRuntime.AppDomainAppPath, appPath[1..].Replace('/', System.IO.Path.DirectorySeparatorChar));
+    }
 
     [Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1024:Use properties where appropriate", Justification = Constants.ApiFromAspNet)]
     public Exception? GetLastError() => null;

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpServerUtility.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpServerUtility.cs
@@ -25,10 +25,7 @@ public class HttpServerUtility
             VirtualPathUtility.Combine(
                 VirtualPathUtility.GetDirectory(_context.Request.Path) ?? "/"
                 , path));
-        // Potential alternative implementations here - for the most literal match to the original use HttpRuntime.AppDomainAppPath
         var rootPath = HttpRuntime.AppDomainAppPath;
-        //var rootPath = _context.RequestServices.GetRequiredService<IWebHostEnvironment>().WebRootPath;
-        //var rootPath = _context.RequestServices.GetRequiredService<IWebHostEnvironment>().ContentRootPath;
         if (string.IsNullOrEmpty(appPath)) return rootPath;
         return System.IO.Path.Combine(rootPath,
             appPath[1..]

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpServerUtility.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpServerUtility.cs
@@ -21,16 +21,16 @@ public class HttpServerUtility
 
     public string MapPath(string? path)
     {
-        var appPath = path is null ? VirtualPathUtility.GetDirectory(_context.Request.Path) :
+        var appPath = (path is null ? VirtualPathUtility.GetDirectory(_context.Request.Path) :
             VirtualPathUtility.Combine(
-            VirtualPathUtility.GetDirectory(_context.Request.Path) ?? "/"
-            , path);
+                VirtualPathUtility.GetDirectory(_context.Request.Path) ?? "/"
+                , path));
         // Potential alternative implementations here - for the most literal match to the original use HttpRuntime.AppDomainAppPath
         var rootPath = HttpRuntime.AppDomainAppPath;
         //var rootPath = _context.RequestServices.GetRequiredService<IWebHostEnvironment>().WebRootPath;
         //var rootPath = _context.RequestServices.GetRequiredService<IWebHostEnvironment>().ContentRootPath;
         if (string.IsNullOrEmpty(appPath)) return rootPath;
-        return System.IO.Path.Combine(rootPath, appPath[1..].Replace('/', System.IO.Path.DirectorySeparatorChar));
+        return System.IO.Path.Combine(rootPath, appPath[1..].Replace('/', System.IO.Path.DirectorySeparatorChar)).TrimEnd('\\');
     }
 
     [Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1024:Use properties where appropriate", Justification = Constants.ApiFromAspNet)]

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpServerUtility.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpServerUtility.cs
@@ -30,7 +30,10 @@ public class HttpServerUtility
         //var rootPath = _context.RequestServices.GetRequiredService<IWebHostEnvironment>().WebRootPath;
         //var rootPath = _context.RequestServices.GetRequiredService<IWebHostEnvironment>().ContentRootPath;
         if (string.IsNullOrEmpty(appPath)) return rootPath;
-        return System.IO.Path.Combine(rootPath, appPath[1..].Replace('/', System.IO.Path.DirectorySeparatorChar)).TrimEnd('\\');
+        return System.IO.Path.Combine(rootPath,
+            appPath[1..]
+            .Replace('/', System.IO.Path.DirectorySeparatorChar))
+            .TrimEnd(System.IO.Path.DirectorySeparatorChar);
     }
 
     [Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1024:Use properties where appropriate", Justification = Constants.ApiFromAspNet)]

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpServerUtility.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpServerUtility.cs
@@ -21,7 +21,7 @@ public class HttpServerUtility
 
     public string MapPath(string? path)
     {
-        var appPath = (path is null ? VirtualPathUtility.GetDirectory(_context.Request.Path) :
+        var appPath = (string.IsNullOrEmpty(path) ? VirtualPathUtility.GetDirectory(_context.Request.Path) :
             VirtualPathUtility.Combine(
                 VirtualPathUtility.GetDirectory(_context.Request.Path) ?? "/"
                 , path));

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpServerUtilityBase.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpServerUtilityBase.cs
@@ -10,7 +10,6 @@ public class HttpServerUtilityBase
 {
     public virtual string MachineName => throw new NotImplementedException();
 
-    [Obsolete(Constants.NotImplemented)]
     public virtual string MapPath(string path) => throw new NotImplementedException();
 
     public virtual Exception? GetLastError() => throw new NotImplementedException();

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpServerUtilityWrapper.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpServerUtilityWrapper.cs
@@ -18,7 +18,6 @@ public class HttpServerUtilityWrapper : HttpServerUtilityBase
 
     public override string MachineName => _utility.MachineName;
 
-    [Obsolete(Constants.NotImplemented)]
     public override string MapPath(string path) => _utility.MapPath(path);
 
     public override byte[]? UrlTokenDecode(string input) => HttpServerUtility.UrlTokenDecode(input);

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpServerUtilityTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpServerUtilityTests.cs
@@ -89,10 +89,13 @@ public class HttpServerUtilityTests
 
     // Test data from https://docs.microsoft.com/en-us/dotnet/api/system.web.httpserverutility.mappath?view=netframework-4.8
     [InlineData("/RootLevelPage.aspx",null,"C:\\ExampleSites\\TestMapPath")]
+    [InlineData("/RootLevelPage.aspx", "", "C:\\ExampleSites\\TestMapPath")]
     [InlineData("/RootLevelPage.aspx", "/DownOneLevel/DownLevelPage.aspx", "C:\\ExampleSites\\TestMapPath\\DownOneLevel\\DownLevelPage.aspx")]
     [InlineData("/RootLevelPage.aspx", "/NotRealFolder", "C:\\ExampleSites\\TestMapPath\\NotRealFolder")]
     [InlineData("/DownOneLevel/DownLevelPage.aspx", null, "C:\\ExampleSites\\TestMapPath\\DownOneLevel")]
     [InlineData("/DownOneLevel/DownLevelPage.aspx", "../RootLevelPage.aspx", "C:\\ExampleSites\\TestMapPath\\RootLevelPage.aspx")]
+    [InlineData("/api/test/request/info", null, "C:\\ExampleSites\\TestMapPath\\api\\test\\request")]
+    [InlineData("/api/test/request/info", "", "C:\\ExampleSites\\TestMapPath\\api\\test\\request")]
     [InlineData("/api/test/request/info", "/UploadedFiles", "C:\\ExampleSites\\TestMapPath\\UploadedFiles")]
     [InlineData("/api/test/request/info", "UploadedFiles", "C:\\ExampleSites\\TestMapPath\\api\\test\\request\\UploadedFiles")]
     [InlineData("/api/test/request/info", "~/MyUploadedFiles", "C:\\ExampleSites\\TestMapPath\\MyUploadedFiles")]

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/VirtualPathUtilityTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/VirtualPathUtilityTests.cs
@@ -11,6 +11,7 @@ namespace Microsoft.AspNetCore.SystemWebAdapters.Tests
         internal class DefaultHttpRuntime : IHttpRuntime
         {
             public string AppDomainAppVirtualPath => "/";
+            public string AppDomainAppPath => "C:\\";
         }
 
         [InlineData("/", "/")]


### PR DESCRIPTION
Implement HttpRuntime.AppDomainAppPath, HttpServerUtility.MapPath, and HttpServerUtilityWrapper.MapPath

**Provide support for MapPath**
Paths are mapped relative the application root directory - available as HttpRuntime.AppDomainAppPath

This may not behave as expected, for example if a person uses MapPath to write uploaded files to disk and expects them to be served, due to the way AspNetCore uses ContentRootPath/WebRootPath.
In this case it might be better to implement your own helper function which can use something like
```cs
namespace System.Web.Extensions
{
    public static class MapPathExtension
    {
        public static string MapContentPath(this System.Web.HttpContext context, string? path)
        {
#if NET6_0_OR_GREATER
            var appPath = path is null ? VirtualPathUtility.GetDirectory(context.Request.Path) :
                VirtualPathUtility.Combine(
                VirtualPathUtility.GetDirectory(context.Request.Path) ?? "/"
                , path);
            var coreContext = (Microsoft.AspNetCore.Http.HttpContext)context;
            var rootPath = coreContext.RequestServices.GetRequiredService<IWebHostEnvironment>().WebRootPath;
            if (string.IsNullOrEmpty(appPath)) return rootPath;
            return System.IO.Path.Combine(rootPath, appPath[1..].Replace('/', System.IO.Path.DirectorySeparatorChar));
#else
            return context.Server.MapPath(path);
#endif
        }
    }
}
```

Addresses #183
