### PR TITLE
Handle application paths for remote calls

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Authentication/RemoteAppAuthenticationClientOptions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Authentication/RemoteAppAuthenticationClientOptions.cs
@@ -41,5 +41,11 @@ public class RemoteAppAuthenticationClientOptions : AuthenticationSchemeOptions
     /// services. Requests to authenticate are sent to this endpoint.
     /// </summary>
     [Required]
-    public PathString AuthenticationEndpointPath { get; set; } = AuthenticationConstants.DefaultEndpoint;
+    public PathString AuthenticationEndpointPath
+    {
+        get => Path.Path;
+        set => Path = new(value);
+    }
+
+    internal RelativePathString Path { get; private set; } = new(AuthenticationConstants.DefaultEndpoint);
 }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Authentication/RemoteAppAuthenticationService.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Authentication/RemoteAppAuthenticationService.cs
@@ -85,7 +85,7 @@ internal partial class RemoteAppAuthenticationService : IRemoteAppAuthentication
         // that may matter for authentication. Also include the original request path as
         // as a query parameter so that the ASP.NET app can redirect back to it if an
         // authentication provider attempts to redirect back to the authenticate URL.
-        var url = $"{_options.AuthenticationEndpointPath}?{AuthenticationConstants.OriginalUrlQueryParamName}={WebUtility.UrlEncode(originalRequest.GetEncodedPathAndQuery())}";
+        var url = $"{_options.Path.Relative}?{AuthenticationConstants.OriginalUrlQueryParamName}={WebUtility.UrlEncode(originalRequest.GetEncodedPathAndQuery())}";
         using var authRequest = new HttpRequestMessage(HttpMethod.Get, url);
         AddHeaders(_options.RequestHeadersToForward, originalRequest, authRequest);
 

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/RelativePathString.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/RelativePathString.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.SystemWebAdapters;
+
+internal readonly struct RelativePathString
+{
+    public RelativePathString(PathString path)
+    {
+        Path = path;
+        Relative = "." + path;
+    }
+
+    public PathString Path { get; }
+
+    /// <summary>
+    /// Use when you want the path to be relative to whatever URI you may combine it with
+    /// </summary>
+    public string Relative { get; }
+}

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/RemoteAppClientExtensions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/RemoteAppClientExtensions.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.SystemWebAdapters;
 using Microsoft.Extensions.Options;
 

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/RemoteAppClientExtensions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/RemoteAppClientExtensions.cs
@@ -31,7 +31,7 @@ public static class RemoteAppClientExtensions
         builder.Services.AddOptions<RemoteAppClientOptions>()
             .ValidateDataAnnotations();
 
-        builder.Services.AddTransient<HandleVirtualDirectoryHandler>();
+        builder.Services.AddTransient<VirtualDirectoryHandler>();
         builder.Services.AddHttpClient(RemoteConstants.HttpClientName)
             .ConfigurePrimaryHttpMessageHandler(sp =>
             {
@@ -45,7 +45,7 @@ public static class RemoteAppClientExtensions
                 // Disable cookies in the HTTP client because the service will manage the cookie header directly
                 return new HttpClientHandler { UseCookies = false, AllowAutoRedirect = false };
             })
-            .AddHttpMessageHandler<HandleVirtualDirectoryHandler>()
+            .AddHttpMessageHandler<VirtualDirectoryHandler>()
             .ConfigureHttpClient((sp, client) =>
             {
                 var options = sp.GetRequiredService<IOptions<RemoteAppClientOptions>>().Value;
@@ -81,11 +81,11 @@ public static class RemoteAppClientExtensions
     /// <see cref="HttpClient.BaseAddress"/> is set automatically, but if this is supposed to have a path, then that gets
     /// lost. This handler will append that back if necessary.
     /// </summary>
-    private class HandleVirtualDirectoryHandler : DelegatingHandler
+    private class VirtualDirectoryHandler : DelegatingHandler
     {
         private readonly string? _path;
 
-        public HandleVirtualDirectoryHandler(IOptions<RemoteAppClientOptions> options)
+        public VirtualDirectoryHandler(IOptions<RemoteAppClientOptions> options)
         {
             _path = options.Value.RemoteAppUrl.AbsolutePath;
 

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/RemoteAppClientOptions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/RemoteAppClientOptions.cs
@@ -35,6 +35,11 @@ public class RemoteAppClientOptions
         get => _remoteAppUrl;
         set
         {
+            if (value is null)
+            {
+                throw new ArgumentNullException(nameof(RemoteAppUrl));
+            }
+
             // Path must end in '/' so that it will combine correctly with subpaths
             if (!value.AbsolutePath.EndsWith("/"))
             {

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/RemoteAppClientOptions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/RemoteAppClientOptions.cs
@@ -12,6 +12,8 @@ namespace Microsoft.AspNetCore.SystemWebAdapters;
 /// </summary>
 public class RemoteAppClientOptions
 {
+    private Uri _remoteAppUrl = null!;
+
     /// <summary>
     /// Gets or sets the header used to store the API key
     /// </summary>
@@ -28,7 +30,22 @@ public class RemoteAppClientOptions
     /// Gets or sets the remote app url
     /// </summary>
     [Required]
-    public Uri RemoteAppUrl { get; set; } = null!;
+    public Uri RemoteAppUrl
+    {
+        get => _remoteAppUrl;
+        set
+        {
+            // Path must end in '/' so that it will combine correctly with subpaths
+            if (!value.AbsolutePath.EndsWith("/"))
+            {
+                var builder = new UriBuilder(value);
+                builder.Path += "/";
+                value = builder.Uri;
+            }
+
+            _remoteAppUrl = value;
+        }
+    }
 
     /// <summary>
     /// Gets or sets an <see cref="HttpMessageHandler"/> to use for making requests to the remote app.

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/SessionState/RemoteSession/RemoteAppSessionStateClientOptions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/SessionState/RemoteSession/RemoteAppSessionStateClientOptions.cs
@@ -2,13 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.SystemWebAdapters.SessionState.RemoteSession;
 
 public class RemoteAppSessionStateClientOptions
 {
     [Required]
-    public string SessionEndpointPath { get; set; } = SessionConstants.SessionEndpointPath;
+    public PathString SessionEndpointPath
+    {
+        get => Path.Path;
+        set => Path = new(value);
+    }
+
+    internal RelativePathString Path { get; private set; } = new(SessionConstants.SessionEndpointPath);
 
     /// <summary>
     /// Gets or sets the cookie name that the ASP.NET framework app is expecting to hold the session id

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/SessionState/RemoteSession/RemoteAppSessionStateManager.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/SessionState/RemoteSession/RemoteAppSessionStateManager.cs
@@ -73,7 +73,7 @@ internal partial class RemoteAppSessionStateManager : ISessionManager
     {
         // The request message is manually disposed at a later time
 #pragma warning disable CA2000 // Dispose objects before losing scope
-        var req = new HttpRequestMessage(HttpMethod.Get, _options.SessionEndpointPath);
+        var req = new HttpRequestMessage(HttpMethod.Get, _options.Path.Relative);
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
         AddSessionCookieToHeader(req, sessionId);
@@ -112,7 +112,7 @@ internal partial class RemoteAppSessionStateManager : ISessionManager
     /// </summary>
     private async Task SetOrReleaseSessionData(ISessionState? state, CancellationToken cancellationToken)
     {
-        using var req = new HttpRequestMessage(HttpMethod.Put, _options.SessionEndpointPath);
+        using var req = new HttpRequestMessage(HttpMethod.Put, _options.Path.Relative);
 
         if (state is not null)
         {

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices/RemoteModule.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices/RemoteModule.cs
@@ -50,11 +50,14 @@ internal abstract class RemoteModule : IHttpModule
 
     void IHttpModule.Init(HttpApplication context)
     {
+        var appRelativePath = $"~{Path}";
+
         context.PostMapRequestHandler += (s, _) =>
         {
             var context = ((HttpApplication)s).Context;
 
-            if (!string.Equals(context.Request.Path, Path, StringComparison.Ordinal))
+            // Compare against the AppRelativeCurrentExecutionFilePath to account for potential virtual directories
+            if (!string.Equals(context.Request.AppRelativeCurrentExecutionFilePath, appRelativePath, StringComparison.Ordinal))
             {
                 return;
             }

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/RemoteAppClientOptionsTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/RemoteAppClientOptionsTests.cs
@@ -35,7 +35,11 @@ public class RemoteAppClientOptionsTests
             {
                 options.ApiKey = apiKey;
                 options.ApiKeyHeader = apiKeyHeader;
-                options.RemoteAppUrl = (remoteAppUrl is null ? null : new Uri(remoteAppUrl, UriKind.Absolute))!;
+
+                if (remoteAppUrl is not null)
+                {
+                    options.RemoteAppUrl = new Uri(remoteAppUrl, UriKind.Absolute);
+                }
             }));
 
         using var serviceProvider = services.BuildServiceProvider();


### PR DESCRIPTION
This change does two things:

1) Ensures that the root address ends in a '/' and that the request path starts with a './'. This is done in a way that gets cached and won't be recomputed each request
2) Update the RemoteModule to compare the incoming strings against the app relative path that accounts for any application paths or virtual directories.

Fixes #191
