### PR TITLE
Add a playwright test project for MvcApp

### DIFF
--- a/Microsoft.AspNetCore.SystemWebAdapters.sln
+++ b/Microsoft.AspNetCore.SystemWebAdapters.sln
@@ -53,7 +53,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Forms", "Forms", "{78F7011B
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "OIDC", "OIDC", "{134659FA-F2BB-4E54-BB68-49E88EA2778F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices", "src\Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices\Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices.csproj", "{6931FEFB-DC18-4B3F-8AFC-EDA03063A518}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices", "src\Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices\Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices.csproj", "{6931FEFB-DC18-4B3F-8AFC-EDA03063A518}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.MVCApp.Tests", "test\Samples.MVCApp.Tests\Samples.MVCApp.Tests.csproj", "{C4F5601D-8D33-4C95-BCFD-EDEF1DC095B4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -121,6 +123,10 @@ Global
 		{6931FEFB-DC18-4B3F-8AFC-EDA03063A518}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6931FEFB-DC18-4B3F-8AFC-EDA03063A518}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6931FEFB-DC18-4B3F-8AFC-EDA03063A518}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C4F5601D-8D33-4C95-BCFD-EDEF1DC095B4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C4F5601D-8D33-4C95-BCFD-EDEF1DC095B4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C4F5601D-8D33-4C95-BCFD-EDEF1DC095B4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C4F5601D-8D33-4C95-BCFD-EDEF1DC095B4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -145,6 +151,7 @@ Global
 		{78F7011B-1C83-4AFC-B163-32420EB10ECA} = {25382551-D3BE-46C0-AAB5-8D2C64D4EDDD}
 		{134659FA-F2BB-4E54-BB68-49E88EA2778F} = {25382551-D3BE-46C0-AAB5-8D2C64D4EDDD}
 		{6931FEFB-DC18-4B3F-8AFC-EDA03063A518} = {F9DB9323-C919-49E8-8F96-B923D2F42E60}
+		{C4F5601D-8D33-4C95-BCFD-EDEF1DC095B4} = {A1BDA50C-D70B-416C-97F1-74B0649797C5}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DABA3C65-9D74-4EB6-9B1C-730328710EAD}

--- a/test/Samples.MVCApp.Tests/MVCSampleTest.cs
+++ b/test/Samples.MVCApp.Tests/MVCSampleTest.cs
@@ -1,16 +1,20 @@
 using Microsoft.Playwright.NUnit;
+using NUnit.Framework;
 
 namespace PlaywrightTests;
 
 [Parallelizable(ParallelScope.Self)]
 public class MvcSampleTest : PageTest
 {
+    private const string MvcAppUrl = "https://localhost:44339/";
+    private const string MvcCoreAppUrl = "https://localhost:55442/";
+
     [Test]
     public async Task MVCCoreAppCanLogoutBothApps()
     {
         var email = $"{Path.GetRandomFileName()}@test.com";
 
-        await Page.GotoAsync("https://localhost:44339/");
+        await Page.GotoAsync(MvcAppUrl);
         await Expect(Page.Locator("text=My ASP.NET Application")).ToBeVisibleAsync();
 
         // Create the user
@@ -22,13 +26,13 @@ public class MvcSampleTest : PageTest
         await Expect(Page.Locator($"text=Hello {email}!")).ToBeVisibleAsync();
 
         // Make sure core app also logged in
-        await Page.GotoAsync("https://localhost:55442/");
+        await Page.GotoAsync(MvcCoreAppUrl);
         await Expect(Page.Locator($"text=Hello {email}!")).ToBeVisibleAsync();
 
         // Logout on core app and make sure both logged out
         await Page.Locator(@"text=Log out").ClickAsync();
         await Expect(Page.Locator(@"text=Log in")).ToBeVisibleAsync();
-        await Page.GotoAsync("https://localhost:44339/");
+        await Page.GotoAsync(MvcAppUrl);
         await Expect(Page.Locator(@"text=Log in")).ToBeVisibleAsync();
     }
 
@@ -38,7 +42,7 @@ public class MvcSampleTest : PageTest
         var email = $"{Path.GetRandomFileName()}@test.com";
 
         // Login with core app
-        await Page.GotoAsync("https://localhost:55442/");
+        await Page.GotoAsync(MvcCoreAppUrl);
         await Expect(Page.Locator("text=ASP.NET Core")).ToBeVisibleAsync();
 
         // Create the user
@@ -50,13 +54,13 @@ public class MvcSampleTest : PageTest
         await Expect(Page.Locator($"text=Hello {email}!")).ToBeVisibleAsync();
 
         // Make sure framework app also logged in
-        await Page.GotoAsync("https://localhost:44339/");
+        await Page.GotoAsync(MvcAppUrl);
         await Expect(Page.Locator($"text=Hello {email}!")).ToBeVisibleAsync();
 
         // Logout on framework app and make sure both logged out
         await Page.Locator(@"text=Log out").ClickAsync();
         await Expect(Page.Locator(@"text=Log in")).ToBeVisibleAsync();
-        await Page.GotoAsync("https://localhost:55442/");
+        await Page.GotoAsync(MvcCoreAppUrl);
         await Expect(Page.Locator(@"text=Log in")).ToBeVisibleAsync();
     }
 }

--- a/test/Samples.MVCApp.Tests/MVCSampleTest.cs
+++ b/test/Samples.MVCApp.Tests/MVCSampleTest.cs
@@ -8,19 +8,22 @@ public class MvcSampleTest : PageTest
     [Test]
     public async Task MVCCoreAppCanLogoutBothApps()
     {
-        // Login with mvc app
+        var email = $"{Path.GetRandomFileName()}@test.com";
+
         await Page.GotoAsync("https://localhost:44339/");
         await Expect(Page.Locator("text=My ASP.NET Application")).ToBeVisibleAsync();
-        await Page.Locator("text=Log in").ClickAsync();
-        await Expect(Page.Locator("text=Use a local account to log in.")).ToBeVisibleAsync();
-        await Page.Locator("input[name=Email]").TypeAsync("test@test.com");
+
+        // Create the user
+        await Page.Locator("text=Register").ClickAsync();
+        await Page.Locator("input[name=Email]").TypeAsync(email);
         await Page.Locator("input[name=Password]").TypeAsync("1qaz!QAZ");
-        await Page.Locator(@"input:has-text(""Log in"")").ClickAsync();
-        await Expect(Page.Locator(@"text=Hello test@test.com!")).ToBeVisibleAsync();
+        await Page.Locator("input[name=ConfirmPassword]").TypeAsync("1qaz!QAZ");
+        await Page.Locator(@"input:has-text(""Register"")").ClickAsync();
+        await Expect(Page.Locator($"text=Hello {email}!")).ToBeVisibleAsync();
 
         // Make sure core app also logged in
         await Page.GotoAsync("https://localhost:55442/");
-        await Expect(Page.Locator(@"text=Hello test@test.com!")).ToBeVisibleAsync();
+        await Expect(Page.Locator($"text=Hello {email}!")).ToBeVisibleAsync();
 
         // Logout on core app and make sure both logged out
         await Page.Locator(@"text=Log out").ClickAsync();
@@ -32,19 +35,23 @@ public class MvcSampleTest : PageTest
     [Test]
     public async Task MVCAppCanLogoutBothApps()
     {
+        var email = $"{Path.GetRandomFileName()}@test.com";
+
         // Login with core app
         await Page.GotoAsync("https://localhost:55442/");
         await Expect(Page.Locator("text=ASP.NET Core")).ToBeVisibleAsync();
-        await Page.Locator("text=Log in").ClickAsync();
-        await Expect(Page.Locator("text=Use a local account to log in.")).ToBeVisibleAsync();
-        await Page.Locator("input[name=Email]").TypeAsync("test@test.com");
+
+        // Create the user
+        await Page.Locator("text=Register").ClickAsync();
+        await Page.Locator("input[name=Email]").TypeAsync(email);
         await Page.Locator("input[name=Password]").TypeAsync("1qaz!QAZ");
-        await Page.Locator(@"input:has-text(""Log in"")").ClickAsync();
-        await Expect(Page.Locator(@"text=Hello test@test.com!")).ToBeVisibleAsync();
+        await Page.Locator("input[name=ConfirmPassword]").TypeAsync("1qaz!QAZ");
+        await Page.Locator(@"input:has-text(""Register"")").ClickAsync();
+        await Expect(Page.Locator($"text=Hello {email}!")).ToBeVisibleAsync();
 
         // Make sure framework app also logged in
         await Page.GotoAsync("https://localhost:44339/");
-        await Expect(Page.Locator(@"text=Hello test@test.com!")).ToBeVisibleAsync();
+        await Expect(Page.Locator($"text=Hello {email}!")).ToBeVisibleAsync();
 
         // Logout on framework app and make sure both logged out
         await Page.Locator(@"text=Log out").ClickAsync();

--- a/test/Samples.MVCApp.Tests/MVCSampleTest.cs
+++ b/test/Samples.MVCApp.Tests/MVCSampleTest.cs
@@ -1,0 +1,55 @@
+using Microsoft.Playwright.NUnit;
+
+namespace PlaywrightTests;
+
+[Parallelizable(ParallelScope.Self)]
+public class MvcSampleTest : PageTest
+{
+    [Test]
+    public async Task MVCCoreAppCanLogoutBothApps()
+    {
+        // Login with mvc app
+        await Page.GotoAsync("https://localhost:44339/");
+        await Expect(Page.Locator("text=My ASP.NET Application")).ToBeVisibleAsync();
+        await Page.Locator("text=Log in").ClickAsync();
+        await Expect(Page.Locator("text=Use a local account to log in.")).ToBeVisibleAsync();
+        await Page.Locator("input[name=Email]").TypeAsync("test@test.com");
+        await Page.Locator("input[name=Password]").TypeAsync("1qaz!QAZ");
+        await Page.Locator(@"input:has-text(""Log in"")").ClickAsync();
+        await Expect(Page.Locator(@"text=Hello test@test.com!")).ToBeVisibleAsync();
+
+        // Make sure core app also logged in
+        await Page.GotoAsync("https://localhost:55442/");
+        await Expect(Page.Locator(@"text=Hello test@test.com!")).ToBeVisibleAsync();
+
+        // Logout on core app and make sure both logged out
+        await Page.Locator(@"text=Log out").ClickAsync();
+        await Expect(Page.Locator(@"text=Log in")).ToBeVisibleAsync();
+        await Page.GotoAsync("https://localhost:44339/");
+        await Expect(Page.Locator(@"text=Log in")).ToBeVisibleAsync();
+    }
+
+    [Test]
+    public async Task MVCAppCanLogoutBothApps()
+    {
+        // Login with core app
+        await Page.GotoAsync("https://localhost:55442/");
+        await Expect(Page.Locator("text=ASP.NET Core")).ToBeVisibleAsync();
+        await Page.Locator("text=Log in").ClickAsync();
+        await Expect(Page.Locator("text=Use a local account to log in.")).ToBeVisibleAsync();
+        await Page.Locator("input[name=Email]").TypeAsync("test@test.com");
+        await Page.Locator("input[name=Password]").TypeAsync("1qaz!QAZ");
+        await Page.Locator(@"input:has-text(""Log in"")").ClickAsync();
+        await Expect(Page.Locator(@"text=Hello test@test.com!")).ToBeVisibleAsync();
+
+        // Make sure framework app also logged in
+        await Page.GotoAsync("https://localhost:44339/");
+        await Expect(Page.Locator(@"text=Hello test@test.com!")).ToBeVisibleAsync();
+
+        // Logout on framework app and make sure both logged out
+        await Page.Locator(@"text=Log out").ClickAsync();
+        await Expect(Page.Locator(@"text=Log in")).ToBeVisibleAsync();
+        await Page.GotoAsync("https://localhost:55442/");
+        await Expect(Page.Locator(@"text=Log in")).ToBeVisibleAsync();
+    }
+}

--- a/test/Samples.MVCApp.Tests/README.md
+++ b/test/Samples.MVCApp.Tests/README.md
@@ -1,0 +1,10 @@
+# Playwright tests for MvcApp and MvcCoreApp
+
+This project is meant to be used to verify functionality of the MvcApp and MvcCoreApp sample apps using playwright.
+
+## Set up
+
+- These tests currently expect the sample apps to be run, i.e. run both MvcApp and MvcCoreApp from the sln.
+- Run `dotnet test` to launch the playwright tests.
+- Set PWDEBUG=1 in the environment to enable the playwright debugger which is super helpful.
+

--- a/test/Samples.MVCApp.Tests/Samples.MVCApp.Tests.csproj
+++ b/test/Samples.MVCApp.Tests/Samples.MVCApp.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/test/Samples.MVCApp.Tests/Samples.MVCApp.Tests.csproj
+++ b/test/Samples.MVCApp.Tests/Samples.MVCApp.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Microsoft.Playwright.NUnit" Version="1.25.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+  </ItemGroup>
+
+</Project>

--- a/test/Samples.MVCApp.Tests/Usings.cs
+++ b/test/Samples.MVCApp.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using NUnit.Framework;

--- a/test/Samples.MVCApp.Tests/Usings.cs
+++ b/test/Samples.MVCApp.Tests/Usings.cs
@@ -1,1 +1,0 @@
-global using NUnit.Framework;


### PR DESCRIPTION
Initial basic test that verifies login/logout works across Mvc[Core]App using playwright

Currently both apps need to be started externally before running dotnet test on the playwright tests, the current idea is that we will ask CTI to run these tests once a month