### PR TITLE
Ensure default response headers are only set if empty

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponse.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponse.cs
@@ -173,7 +173,7 @@ namespace System.Web
         {
             if (_response.Headers.TryGetValue(name, out var existing))
             {
-                _response.Headers.Add(name, StringValues.Concat(existing, value));
+                _response.Headers[name] = StringValues.Concat(existing, value);
             }
             else
             {

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/SetDefaultResponseHeadersMiddlewareTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/SetDefaultResponseHeadersMiddlewareTests.cs
@@ -1,8 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Xunit;
 
 namespace Microsoft.AspNetCore.SystemWebAdapters.Tests;
@@ -14,11 +16,14 @@ public class SetDefaultResponseHeadersMiddlewareTests
     {
         // Arrange
         var context = new DefaultHttpContext();
+        var startupFeature = new StartupCallbackFeature();
+        context.Features.Set<IHttpResponseFeature>(startupFeature);
         var next = Task (HttpContextCore context) => Task.CompletedTask;
         var middleware = new SetDefaultResponseHeadersMiddleware(new(next));
 
         // Act
         await middleware.InvokeAsync(context);
+        await startupFeature.RunAsync();
 
         // Assert
         Assert.Equal(2, context.Response.Headers.Count);
@@ -33,6 +38,9 @@ public class SetDefaultResponseHeadersMiddlewareTests
     {
         // Arrange
         var context = new DefaultHttpContext();
+        var startupFeature = new StartupCallbackFeature();
+        context.Features.Set<IHttpResponseFeature>(startupFeature);
+
         context.Response.Headers[name] = value;
 
         var next = Task (HttpContextCore context) => Task.CompletedTask;
@@ -40,8 +48,57 @@ public class SetDefaultResponseHeadersMiddlewareTests
 
         // Act
         await middleware.InvokeAsync(context);
+        await startupFeature.RunAsync();
 
         // Assert
         Assert.Equal(value, context.Response.Headers[name]);
+    }
+
+    [Theory]
+    [InlineData("Content-Type", "some-content-type")]
+    [InlineData("Cache-Control", "cache-value")]
+    public async Task AddedInLaterMiddleware(string name, string value)
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+        var startupFeature = new StartupCallbackFeature();
+        context.Features.Set<IHttpResponseFeature>(startupFeature);
+
+        var next = Task (HttpContextCore context) =>
+        {
+            var adapter = context.GetAdapter();
+            adapter.Response.AppendHeader(name, value);
+
+            return Task.CompletedTask;
+        };
+        var middleware = new SetDefaultResponseHeadersMiddleware(new(next));
+
+        // Act
+        await middleware.InvokeAsync(context);
+        await startupFeature.RunAsync();
+
+        // Assert
+        Assert.Equal(value, context.Response.Headers[name]);
+    }
+
+    // The default feature does not include a functional `OnStarting` method
+    private class StartupCallbackFeature : HttpResponseFeature
+    {
+        private Func<Task>? _callback;
+
+        public override void OnStarting(Func<object, Task> callback, object state)
+        {
+            _callback = () => callback(state);
+        }
+
+        public Task RunAsync()
+        {
+            if (_callback is null)
+            {
+                throw new InvalidOperationException();
+            }
+
+            return _callback();
+        }
     }
 }


### PR DESCRIPTION
This change moves it to be on the `Response.OnStarting` call rather than at the beginning of the request. As part of this, a bug in `HttpRequest.AppendHeader` was fixed.

Fixes #203
