### PR TITLE
Replace IRequestBodyPipeFeature if prebuffering

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/PreBufferRequestStreamMiddleware.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/PreBufferRequestStreamMiddleware.cs
@@ -28,6 +28,7 @@ internal partial class PreBufferRequestStreamMiddleware
         context.Response.RegisterForDispose(requestFeature);
         context.Features.Set<IHttpRequestFeature>(requestFeature);
         context.Features.Set<IHttpRequestAdapterFeature>(requestFeature);
+        context.Features.Set<IRequestBodyPipeFeature>(requestFeature);
 
         await _next(context);
     }


### PR DESCRIPTION
We currently replace the IHttpRequestFeature, but that gets the IRequestBodyPipeFeature.Reader out of sync if the stream is prebuffered. This change implements IRequestBodyPipeFeature on our custom feature and sets it as well.

