### PR TITLE
Ensure multi-cookie headers are joined with ; instead of ,

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Authentication/RemoteAppAuthenticationService.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Authentication/RemoteAppAuthenticationService.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.SystemWebAdapters.Authentication;
 
@@ -97,7 +98,7 @@ internal partial class RemoteAppAuthenticationService : IRemoteAppAuthentication
     }
 
     // Add configured headers to the request, or all headers if none in particular are specified
-    private static void AddHeaders(IEnumerable<string> headersToForward, HttpRequest originalRequest, HttpRequestMessage authRequest)
+    internal static void AddHeaders(IEnumerable<string> headersToForward, HttpRequest originalRequest, HttpRequestMessage authRequest)
     {
         // Add x-forwarded headers so that the authenticate API will know which host the HTTP request was addressed to originally.
         // These headers are also used by result processors - to fix-up redirect responses, for example, to redirect back to the
@@ -118,6 +119,14 @@ internal partial class RemoteAppAuthenticationService : IRemoteAppAuthentication
 
         foreach (var headerName in headerNames)
         {
+            // HttpClient wrongly uses comma (",") instead of semi-colon (";") as a separator for Cookie headers.
+            // To mitigate this, we concatenate them manually and put them back as a single header value.
+            if (string.Equals(headerName, HeaderNames.Cookie, StringComparison.OrdinalIgnoreCase))
+            {
+                authRequest.Headers.Add(headerName, string.Join("; ", originalRequest.Headers[headerName].ToArray()));
+                continue;
+            }
+
             authRequest.Headers.Add(headerName, originalRequest.Headers[headerName].ToArray());
         }
     }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Authentication/RemoteAppAuthenticationService.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Authentication/RemoteAppAuthenticationService.cs
@@ -119,8 +119,10 @@ internal partial class RemoteAppAuthenticationService : IRemoteAppAuthentication
 
         foreach (var headerName in headerNames)
         {
+            // Workaround for an issue identified by https://github.com/dotnet/systemweb-adapters/issues/228.
             // HttpClient wrongly uses comma (",") instead of semi-colon (";") as a separator for Cookie headers.
             // To mitigate this, we concatenate them manually and put them back as a single header value.
+            // This workaround can be removed once we target .NET 7+ as HttpClient is fixed there.
             if (string.Equals(headerName, HeaderNames.Cookie, StringComparison.OrdinalIgnoreCase))
             {
                 authRequest.Headers.Add(headerName, string.Join("; ", originalRequest.Headers[headerName].ToArray()));

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Authentication/RemoteAppAuthenticationService.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Authentication/RemoteAppAuthenticationService.cs
@@ -122,7 +122,7 @@ internal partial class RemoteAppAuthenticationService : IRemoteAppAuthentication
             // Workaround for an issue identified by https://github.com/dotnet/systemweb-adapters/issues/228.
             // HttpClient wrongly uses comma (",") instead of semi-colon (";") as a separator for Cookie headers.
             // To mitigate this, we concatenate them manually and put them back as a single header value.
-            // This workaround can be removed once we target .NET 7+ as HttpClient is fixed there.
+            // This workaround can be removed once we target .NET 7+ as Kestrel is fixed there.
             if (string.Equals(headerName, HeaderNames.Cookie, StringComparison.OrdinalIgnoreCase))
             {
                 authRequest.Headers.Add(headerName, string.Join("; ", originalRequest.Headers[headerName].ToArray()));

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/Authentication/RemoteAppAuthenticationServiceTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/Authentication/RemoteAppAuthenticationServiceTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.SystemWebAdapters.Authentication.Tests;
+
+public class RemoteAppAuthenticationServiceTests
+{
+    [Theory]
+    [MemberData(nameof(GetHeadersForConcatenation))]
+    public void AddHeadersConcatenation(Dictionary<string, StringValues> originalHeaders, Dictionary<string, StringValues> resultHeaders)
+    {
+        var originalRequest = new Mock<HttpRequestCore>();
+        originalRequest.Setup(r => r.Headers).Returns(new HeaderDictionary(originalHeaders));
+        originalRequest.Setup(r => r.Scheme).Returns("scheme");
+        originalRequest.Setup(r => r.Host).Returns(new HostString("host"));
+
+        // Add additional headers that are added to the original request's headers
+        resultHeaders.Add(AuthenticationConstants.ForwardedHostHeaderName, "host");
+        resultHeaders.Add(AuthenticationConstants.ForwardedProtoHeaderName, "scheme");
+        resultHeaders.Add(AuthenticationConstants.MigrationAuthenticateRequestHeaderName, "true");
+
+        var authRequest = new HttpRequestMessage();
+
+        RemoteAppAuthenticationService.AddHeaders(originalHeaders.Keys, originalRequest.Object, authRequest);
+
+        Assert.Collection(
+            authRequest.Headers.OrderBy(h => h.Key).Select(h => KeyValuePair.Create(h.Key, new StringValues(h.Value.ToArray()))),
+            resultHeaders.OrderBy(h => h.Key).Select<KeyValuePair<string, StringValues>, Action<KeyValuePair<string, StringValues>>>(
+                expected => (actual =>
+                {
+                    Assert.Equal(expected.Key, actual.Key);
+                    Assert.Equal(expected.Value, actual.Value);
+                })).ToArray());
+    }
+
+    public static IEnumerable<object[]> GetHeadersForConcatenation()
+    {
+        // Trivial positive case
+        yield return new object[]
+        {
+            new Dictionary<string, StringValues>(){ { "A", new StringValues("1") } },
+            new Dictionary<string, StringValues>(){ { "A", new StringValues("1") } }
+        };
+
+        // Multi-header case
+        yield return new object[]
+        {
+            new Dictionary<string, StringValues>(){ { "A", new StringValues(new[] { "1", "2" }) } },
+            new Dictionary<string, StringValues>(){ { "A", new StringValues(new[] { "1", "2" }) } }
+        };
+
+        // Multi-cookie case
+        yield return new object[]
+        {
+            new Dictionary<string, StringValues>(){ { "Cookie", new StringValues(new[] { "1", "2" }) } },
+            new Dictionary<string, StringValues>(){ { "Cookie", new StringValues(new[] { "1; 2" }) } }
+        };
+    }
+}


### PR DESCRIPTION
In cases of multi-headers, HttpClient concatenates the headers with `, `. In the case of multi-header *cookie* headers, though (which can happen because of https://github.com/dotnet/aspnetcore/issues/26461), [RFC 6265](https://datatracker.ietf.org/doc/html/rfc6265#section-4.2) specifies that multiple cookies must be concatenated with `; ` when writing the Cookie header.

HttpClient doesn't special case the Cookie header as it should, so this updates the RemoteAppAuthenticationService to special case cookie headers and concatenate them itself, if needed.

Fixes #228