### PR TITLE
Use a singleton HttpClient for remote app communication

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Authentication/RemoteAppAuthenticationService.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Authentication/RemoteAppAuthenticationService.cs
@@ -30,21 +30,15 @@ internal partial class RemoteAppAuthenticationService : IRemoteAppAuthentication
     private RemoteAppAuthenticationClientOptions? _options;
 
     public RemoteAppAuthenticationService(
-        IHttpClientFactory httpClientFactory,
         IAuthenticationResultFactory resultFactory,
         IOptionsSnapshot<RemoteAppAuthenticationClientOptions> authOptions,
         IOptions<RemoteAppClientOptions> remoteAppOptions,
         ILogger<RemoteAppAuthenticationService> logger)
     {
-        if (httpClientFactory is null)
-        {
-            throw new ArgumentNullException(nameof(httpClientFactory));
-        }
-
         _resultFactory = resultFactory ?? throw new ArgumentNullException(nameof(resultFactory));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _authOptionsSnapshot = authOptions ?? throw new ArgumentNullException(nameof(authOptions));
-        _client = httpClientFactory.CreateClient(RemoteConstants.HttpClientName);
+        _client = remoteAppOptions?.Value.BackchannelClient ?? throw new ArgumentNullException(nameof(remoteAppOptions));
     }
 
     /// <summary>

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/RemoteAppClientExtensions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/RemoteAppClientExtensions.cs
@@ -26,30 +26,10 @@ public static class RemoteAppClientExtensions
             throw new ArgumentNullException(nameof(configure));
         }
 
+        builder.Services.AddSingleton<IPostConfigureOptions<RemoteAppClientOptions>, RemoteAppClientPostConfigureOptions>();
         builder.Services.AddOptions<RemoteAppClientOptions>()
             .Configure(configure)
             .ValidateDataAnnotations();
-
-        builder.Services.AddHttpClient(RemoteConstants.HttpClientName)
-            .ConfigurePrimaryHttpMessageHandler(sp =>
-            {
-                var options = sp.GetRequiredService<IOptions<RemoteAppClientOptions>>().Value;
-
-                if (options.BackchannelHandler is { } handler)
-                {
-                    return handler;
-                }
-
-                // Disable cookies in the HTTP client because the service will manage the cookie header directly
-                return new HttpClientHandler { UseCookies = false, AllowAutoRedirect = false };
-            })
-            .ConfigureHttpClient((sp, client) =>
-            {
-                var options = sp.GetRequiredService<IOptions<RemoteAppClientOptions>>().Value;
-
-                client.BaseAddress = options.RemoteAppUrl;
-                client.DefaultRequestHeaders.Add(options.ApiKeyHeader, options.ApiKey);
-            });
 
         return new Builder(builder.Services);
     }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/RemoteAppClientOptions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/RemoteAppClientOptions.cs
@@ -60,7 +60,5 @@ public class RemoteAppClientOptions
     /// <summary>
     /// Gets or sets an <see cref="HttpClient"/> to use for making requests to the remote app.
     /// </summary>
-    public HttpClient BackchannelClient { get; set; }
-        // Set to default, because we'll ensure this is populated with post-configuration
-        = default!;
+    public HttpClient? BackchannelClient { get; set; }
 }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/RemoteAppClientOptions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/RemoteAppClientOptions.cs
@@ -53,7 +53,14 @@ public class RemoteAppClientOptions
     }
 
     /// <summary>
-    /// Gets or sets an <see cref="HttpMessageHandler"/> to use for making requests to the remote app.
+    /// Gets or sets an <see cref="HttpMessageHandler"/> to use for making requests to the remote app. Used if BackchannelClient is null.
     /// </summary>
     public HttpMessageHandler? BackchannelHandler { get; set; }
+
+    /// <summary>
+    /// Gets or sets an <see cref="HttpClient"/> to use for making requests to the remote app.
+    /// </summary>
+    public HttpClient BackchannelClient { get; set; }
+        // Set to default, because we'll ensure this is populated with post-configuration
+        = default!;
 }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/RemoteAppClientPostConfigureOptions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/RemoteAppClientPostConfigureOptions.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net.Http;
+using Microsoft.AspNetCore.SystemWebAdapters;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+internal class RemoteAppClientPostConfigureOptions : IPostConfigureOptions<RemoteAppClientOptions>
+{
+    public void PostConfigure(string name, RemoteAppClientOptions options)
+    {
+        if (options.BackchannelClient is null)
+        {
+            options.BackchannelClient = new HttpClient(
+                options.BackchannelHandler
+                // Disable cookies in the HTTP client because the service will manage the cookie header directly
+                ?? new HttpClientHandler { UseCookies = false, AllowAutoRedirect = false });
+
+            // Set base address and API key header based on options
+            if (options.RemoteAppUrl is not null)
+            {
+                options.BackchannelClient.BaseAddress = options.RemoteAppUrl;
+            }
+
+            if (!string.IsNullOrEmpty(options.ApiKeyHeader))
+            {
+                options.BackchannelClient.DefaultRequestHeaders.Add(options.ApiKeyHeader, options.ApiKey);
+            }
+        }
+    }
+}

--- a/src/Services/RemoteConstants.cs
+++ b/src/Services/RemoteConstants.cs
@@ -6,6 +6,4 @@ namespace Microsoft.AspNetCore.SystemWebAdapters;
 internal static class RemoteConstants
 {
     internal const string ApiKeyHeaderName = "X-SystemWebAdapter-RemoteAppAuthentication-Key";
-
-    internal const string HttpClientName = "remote-client";
 }


### PR DESCRIPTION
Updates remote app communication to use a singleton HttpClient instance (stored in RemoteAppClientOptions) rather than getting new clients from IHttpClientFactory for each request. This addresses an issue where HTTP handlers provided by users were being disposed and then reused by the factory previously.

Fixes #221 