### PR TITLE
Use HttpValueCollection as base class for custom collections

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,10 +53,10 @@ stages:
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             name: NetCore-Public
-            demands: ImageOverride -equals Build.Server.Amd64.VS2017.Open
+            demands: ImageOverride -equals 1es-windows-2019-open
           ${{ if ne(variables['System.TeamProject'], 'public') }}:
             name: NetCore1ESPool-Internal
-            demands: ImageOverride -equals Build.Server.Amd64.VS2017
+            demands: ImageOverride -equals 1es-windows-2019
         variables:
         - name: _HelixBuildConfig
           value: $(_BuildConfig)

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Internal/HttpValueCollection.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Internal/HttpValueCollection.cs
@@ -87,7 +87,7 @@ internal class HttpValueCollection : NameValueCollection
         }
     }
 
-    public override string ToString() => ToString(false);
+    public override string ToString() => ToString(true);
 
     private string ToString(bool urlencoded)
     {
@@ -100,9 +100,9 @@ internal class HttpValueCollection : NameValueCollection
 
         var s = new StringBuilder();
 
-        for (var i = 0; i < count; i++)
+        foreach (string k in this)
         {
-            var key = GetKey(i);
+            var key = k;
 
             if (urlencoded)
             {
@@ -110,7 +110,7 @@ internal class HttpValueCollection : NameValueCollection
             }
 
             var keyPrefix = string.IsNullOrEmpty(key) ? string.Empty : $"{key}=";
-            var values = (ArrayList?)BaseGet(i);
+            var values = GetValues(k);
 
             if (s.Length > 0)
             {
@@ -122,7 +122,7 @@ internal class HttpValueCollection : NameValueCollection
                 continue;
             }
 
-            for (var j = 0; j < values.Count; j++)
+            for (var j = 0; j < values.Length; j++)
             {
                 if (j > 0)
                 {

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Internal/NoGetByIntNameValueCollection.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Internal/NoGetByIntNameValueCollection.cs
@@ -1,9 +1,8 @@
 using System;
-using System.Collections.Specialized;
 
 namespace Microsoft.AspNetCore.SystemWebAdapters.Internal;
 
-internal abstract class NoGetByIntNameValueCollection : NameValueCollection
+internal abstract class NoGetByIntNameValueCollection : HttpValueCollection
 {
     private protected const string IndexErrorMessage = "ASP.NET Core doesn't support accessing items by index.";
 

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpRequestTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpRequestTests.cs
@@ -686,6 +686,7 @@ namespace Microsoft.AspNetCore.SystemWebAdapters
             // Assert
             Assert.Same(serverVariables1, serverVariables2);
             Assert.IsType<ServerVariablesNameValueCollection>(serverVariables1);
+            Assert.Throws<PlatformNotSupportedException>(() => serverVariables1.ToString());
         }
 
         [Fact]
@@ -757,6 +758,7 @@ namespace Microsoft.AspNetCore.SystemWebAdapters
             Assert.Equal(new[] { value1 }, form.GetValues(key1));
             Assert.Equal($"{value2},{value3}", form.Get(key2));
             Assert.Equal(new[] { value2, value3 }, form.GetValues(key2));
+            Assert.Equal($"{key1}={value1}&{key2}={value2}&{key2}={value3}", form.ToString());
         }
 
         [Fact]
@@ -778,6 +780,29 @@ namespace Microsoft.AspNetCore.SystemWebAdapters
             // Assert
             Assert.Same(queryCollection1, queryCollection2);
             Assert.IsType<StringValuesReadOnlyDictionaryNameValueCollection>(queryCollection1);
+        }
+
+        [Fact]
+        public void QueryToString()
+        {
+            // Arrange
+            var query = new QueryCollection(new Dictionary<string, StringValues>()
+            {
+                { "q", "1" },
+                { "t", "1,2,3" },
+                { "w", new StringValues(new[] { "5", "6" }) },
+            });
+
+            var requestCore = new Mock<HttpRequestCore>();
+            requestCore.Setup(r => r.Query).Returns(query);
+
+            var request = new HttpRequest(requestCore.Object);
+
+            // Act
+            var str = request.QueryString.ToString();
+
+            // Assert
+            Assert.Equal("q=1&t=1%2c2%2c3&w=5&w=6", str);
         }
 
         [Fact]


### PR DESCRIPTION
This enables .ToString() to function as similarly to .NET Framework as
possible. That's the only observable difference by adding this as the
base class.
