### PR TITLE
Small doc fix

### DIFF
--- a/docs/remote-app-setup.md
+++ b/docs/remote-app-setup.md
@@ -32,7 +32,7 @@ builder.Services.AddSystemWebAdapters()
     .AddRemoteAppClient(options =>
     {
         options.RemoteAppUrl = new(builder.Configuration["ReverseProxy:Clusters:fallbackCluster:Destinations:fallbackApp:Address"]);
-        options.ApiKey = builder.Configuration("RemoteAppApiKey");
+        options.ApiKey = builder.Configuration["RemoteAppApiKey"];
     });
 ```
 


### PR DESCRIPTION
Fix a code snippet in remote api setup docs to use `[]` to index into IConfiguration instead of `()`.
