### PR TITLE
Add extension method to enumerate keys efficiently

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/NameValueCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/NameValueCollectionExtensions.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+
+#if NET6_0_OR_GREATER
+using Microsoft.AspNetCore.SystemWebAdapters.Internal;
+#endif
+
+namespace System.Web;
+
+public static class NameValueCollectionExtensions
+{
+    public static IEnumerable<string?> EnumerateKeys(this NameValueCollection collection)
+    {
+#if NET6_0_OR_GREATER
+        if (collection is IKeyEnumerator keys)
+        {
+            return keys.Keys;
+        }
+        else if (collection is NoGetByIntNameValueCollection)
+        {
+            return collection.AllKeys;
+        }
+        else
+#endif
+        {
+            return collection.OfType<string>();
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/ExcludedApis.txt
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/ExcludedApis.txt
@@ -10,6 +10,8 @@ M:System.Web.HttpResponse.op_Implicit(System.Web.HttpResponse)~Microsoft.AspNetC
 M:System.Web.HttpResponseBase.op_Implicit(Microsoft.AspNetCore.Http.HttpResponse)~System.Web.HttpResponseBase
 M:System.Web.HttpRequestBase.op_Implicit(Microsoft.AspNetCore.Http.HttpRequest)~System.Web.HttpRequestBase
 
+T:System.Web.NameValueCollectionExtensions
+
 T:Microsoft.AspNetCore.SystemWebAdapters.SessionState.ISessionState
 
 # We manually type forward this only for .NET 4.7.2+

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Internal/IKeyEnumerator.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Internal/IKeyEnumerator.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.SystemWebAdapters.Internal;
+
+internal interface IKeyEnumerator
+{
+    IEnumerable<string> Keys { get; }
+}

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Internal/ParamsCollection.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Internal/ParamsCollection.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Primitives;
 

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Internal/StringValuesDictionaryNameValueCollection.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Internal/StringValuesDictionaryNameValueCollection.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.SystemWebAdapters.Internal
 {
-    internal class StringValuesDictionaryNameValueCollection : NoGetByIntNameValueCollection
+    internal class StringValuesDictionaryNameValueCollection : NoGetByIntNameValueCollection, IKeyEnumerator
     {
         private readonly IDictionary<string, StringValues> _values;
 
@@ -17,6 +17,8 @@ namespace Microsoft.AspNetCore.SystemWebAdapters.Internal
         public override string?[] AllKeys => _values.Keys.ToArray();
 
         public override int Count => _values.Count;
+
+        IEnumerable<string> IKeyEnumerator.Keys => _values.Keys;
 
         public override void Add(string? name, string? value)
         {

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Internal/StringValuesReadOnlyDictionaryNameValueCollection.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Internal/StringValuesReadOnlyDictionaryNameValueCollection.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.SystemWebAdapters.Internal
 {
-    internal class StringValuesReadOnlyDictionaryNameValueCollection : NoGetByIntNameValueCollection
+    internal class StringValuesReadOnlyDictionaryNameValueCollection : NoGetByIntNameValueCollection, IKeyEnumerator
     {
         private readonly IReadOnlyDictionary<string, StringValues> _values;
 
@@ -26,6 +26,8 @@ namespace Microsoft.AspNetCore.SystemWebAdapters.Internal
         public override string?[] AllKeys => _values.Keys.ToArray();
 
         public override int Count => _values.Count;
+
+        IEnumerable<string> IKeyEnumerator.Keys => _values.Keys;
 
         public override string[]? GetValues(string? name)
             => name is not null && _values.TryGetValue(name, out var values) ? values : default;


### PR DESCRIPTION
This will default to the `GetEnumerator()` method on NameValueCollection, but will use more efficient enumeration if possible.

