### PR TITLE
Add more NETFramework-compatible APIs for HttpException

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
@@ -119,16 +119,16 @@ namespace System.Web
     public partial class HttpException : System.SystemException
     {
         public HttpException() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        public HttpException(int httpStatusCode) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        public HttpException(int httpStatusCode, string message) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        public HttpException(int httpStatusCode, string message, System.Exception innerException) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        public HttpException(System.Net.HttpStatusCode httpStatusCode) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        public HttpException(System.Net.HttpStatusCode httpStatusCode, string message) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        public HttpException(System.Net.HttpStatusCode httpStatusCode, string message, System.Exception innerException) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public HttpException(string message) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public HttpException(string message, System.Exception innerException) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
-        public HttpException(int httpStatusCode) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
-        public HttpException(System.Net.HttpStatusCode httpStatusCode) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
-        public HttpException(int httpStatusCode, string message) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
-        public HttpException(System.Net.HttpStatusCode httpStatusCode, string message) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
-        public HttpException(int httpStatusCode, string message, System.Exception innerException) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
-        public HttpException(System.Net.HttpStatusCode httpStatusCode, string message, System.Exception innerException) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
-        public int GetHttpCode() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public int StatusCode { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public int GetHttpCode() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
     }
     public sealed partial class HttpFileCollection : System.Collections.Specialized.NameObjectCollectionBase
     {

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
@@ -121,6 +121,14 @@ namespace System.Web
         public HttpException() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public HttpException(string message) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public HttpException(string message, System.Exception innerException) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        public HttpException(int httpStatusCode) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        public HttpException(System.Net.HttpStatusCode httpStatusCode) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        public HttpException(int httpStatusCode, string message) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        public HttpException(System.Net.HttpStatusCode httpStatusCode, string message) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        public HttpException(int httpStatusCode, string message, System.Exception innerException) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        public HttpException(System.Net.HttpStatusCode httpStatusCode, string message, System.Exception innerException) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        public int GetHttpCode() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        public int StatusCode { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
     }
     public sealed partial class HttpFileCollection : System.Collections.Specialized.NameObjectCollectionBase
     {

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpException.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpException.cs
@@ -1,10 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Net;
+
 namespace System.Web;
 
 public class HttpException : SystemException
 {
+    private readonly int httpStatusCode;
+    
     public HttpException()
     {
     }
@@ -16,5 +21,52 @@ public class HttpException : SystemException
     public HttpException(string message, Exception innerException)
         : base(message, innerException)
     {
+    }
+
+    public HttpException(int httpStatusCode)
+    {
+        this.httpStatusCode = httpStatusCode;
+    }
+
+    public HttpException(HttpStatusCode httpStatusCode)
+    {
+        this.httpStatusCode = (int)httpStatusCode;
+    }
+
+    public HttpException(int httpStatusCode, string message)
+        : base(message)
+    {
+        this.httpStatusCode = httpStatusCode;
+    }
+
+    public HttpException(HttpStatusCode httpStatusCode, string message)
+        : base(message)
+    {
+        this.httpStatusCode = (int)httpStatusCode;
+    }
+
+    public HttpException(int httpStatusCode, string message, Exception innerException)
+        : base(message, innerException)
+    {
+        this.httpStatusCode = httpStatusCode;
+    }
+
+    public HttpException(HttpStatusCode httpStatusCode, string message, Exception innerException)
+        : base(message, innerException)
+    {
+        this.httpStatusCode = (int)httpStatusCode;
+    }
+
+    public int GetHttpCode()
+    {
+        return this.httpStatusCode;
+    }
+
+    public int StatusCode
+    {
+        get
+        {
+            return this.httpStatusCode;
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpException.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpException.cs
@@ -8,7 +8,7 @@ namespace System.Web;
 
 public class HttpException : SystemException
 {
-    private readonly int httpStatusCode;
+    private readonly int httpStatusCode = 500;
     
     public HttpException()
     {

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpException.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpException.cs
@@ -8,7 +8,7 @@ namespace System.Web;
 
 public class HttpException : SystemException
 {
-    private readonly int httpStatusCode = 500;
+    private readonly int _httpStatusCode = 500;
     
     public HttpException()
     {
@@ -25,48 +25,48 @@ public class HttpException : SystemException
 
     public HttpException(int httpStatusCode)
     {
-        this.httpStatusCode = httpStatusCode;
+        _httpStatusCode = httpStatusCode;
     }
 
     public HttpException(HttpStatusCode httpStatusCode)
     {
-        this.httpStatusCode = (int)httpStatusCode;
+        _httpStatusCode = (int)httpStatusCode;
     }
 
     public HttpException(int httpStatusCode, string message)
         : base(message)
     {
-        this.httpStatusCode = httpStatusCode;
+        _httpStatusCode = httpStatusCode;
     }
 
     public HttpException(HttpStatusCode httpStatusCode, string message)
         : base(message)
     {
-        this.httpStatusCode = (int)httpStatusCode;
+        _httpStatusCode = (int)httpStatusCode;
     }
 
     public HttpException(int httpStatusCode, string message, Exception innerException)
         : base(message, innerException)
     {
-        this.httpStatusCode = httpStatusCode;
+        _httpStatusCode = httpStatusCode;
     }
 
     public HttpException(HttpStatusCode httpStatusCode, string message, Exception innerException)
         : base(message, innerException)
     {
-        this.httpStatusCode = (int)httpStatusCode;
+        _httpStatusCode = (int)httpStatusCode;
     }
 
     public int GetHttpCode()
     {
-        return this.httpStatusCode;
+        return _httpStatusCode;
     }
 
     public int StatusCode
     {
         get
         {
-            return this.httpStatusCode;
+            return _httpStatusCode;
         }
     }
 }

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpExceptionTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpExceptionTests.cs
@@ -1,6 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Net;
+using System.Web;
+using AutoFixture;
+using Xunit;
+
 namespace Microsoft.AspNetCore.SystemWebAdapters;
 
 public class HttpExceptionTests

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpExceptionTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpExceptionTests.cs
@@ -1,0 +1,135 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.SystemWebAdapters;
+
+public class HttpExceptionTests
+{
+    [Fact]
+    public void DefaultValues()
+    {
+        // Act
+        var exception = new HttpException();
+
+        // Assert
+        Assert.Equal(500, exception.GetHttpCode());
+    }
+
+    [Fact]
+    public void Create()
+    {
+        // Arrange
+        var message = "message";
+
+        // Act
+        var exception = new HttpException(message);
+
+        // Assert
+        Assert.Equal(message, exception.Message);
+        Assert.Equal(500, exception.GetHttpCode());
+    }
+
+    [Fact]
+    public void CreateWithInnerException()
+    {
+        // Arrange
+        var message = "message";
+        var innerException = new Exception();
+
+        // Act
+        var exception = new HttpException(message, innerException);
+
+        // Assert
+        Assert.Equal(message, exception.Message);
+        Assert.Equal(innerException, exception.InnerException);
+        Assert.Equal(500, exception.GetHttpCode());
+    }
+
+    [Fact]
+    public void CreateWithHttpStatusCode()
+    {
+        // Arrange
+        var httpStatusCode = 404;
+
+        // Act
+        var exception = new HttpException(httpStatusCode);
+
+        // Assert
+        Assert.Equal(httpStatusCode, exception.GetHttpCode());
+    }
+
+    [Fact]
+    public void CreateWithHttpStatusCodeEnum()
+    {
+        // Arrange
+        var httpStatusCode = HttpStatusCode.NotFound;
+
+        // Act
+        var exception = new HttpException(httpStatusCode);
+
+        // Assert
+        Assert.Equal((int)httpStatusCode, exception.GetHttpCode());
+    }
+
+    [Fact]
+    public void CreateWithHttpStatusCodeAndMessage()
+    {
+        // Arrange
+        var httpStatusCode = 404;
+        var message = "message";
+
+        // Act
+        var exception = new HttpException(httpStatusCode, message);
+
+        // Assert
+        Assert.Equal(message, exception.Message);
+        Assert.Equal(httpStatusCode, exception.GetHttpCode());
+    }
+
+    [Fact]
+    public void CreateWithHttpStatusCodeEnumAndMessage()
+    {
+        // Arrange
+        var httpStatusCode = HttpStatusCode.NotFound;
+        var message = "message";
+
+        // Act
+        var exception = new HttpException(httpStatusCode, message);
+
+        // Assert
+        Assert.Equal(message, exception.Message);
+        Assert.Equal((int)httpStatusCode, exception.GetHttpCode());
+    }
+
+    [Fact]
+    public void CreateWithIntCodeAndMessageAndInnerException()
+    {
+        // Arrange
+        var httpStatusCode = 404;
+        var message = "message";
+        var innerException = new Exception();
+
+        // Act
+        var exception = new HttpException(httpStatusCode, message, innerException);
+
+        // Assert
+        Assert.Equal(message, exception.Message);
+        Assert.Equal(httpStatusCode, exception.GetHttpCode());
+    }
+
+    [Fact]
+    public void CreateWithEnumHttpStatusCodeAndMessageAndInnerException()
+    {
+        // Arrange
+        var httpStatusCode = HttpStatusCode.NotFound;
+        var message = "message";
+        var innerException = new Exception();
+
+        // Act
+        var exception = new HttpException(httpStatusCode, message, innerException);
+
+        // Assert
+        Assert.Equal(message, exception.Message);
+        Assert.Equal((int)httpStatusCode, exception.GetHttpCode());
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the systemweb-adapters repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](../CONTRIBUTING.md) and [Code of Conduct](../CODE-OF-CONDUCT.md).
- [x] You've included unit tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**Add more NETFramework-compatible APIs for HttpException**
As [the HttpException class in .NET Framework](https://learn.microsoft.com/en-us/dotnet/api/system.web.httpexception?source=recommendations&view=netframework-4.8) has more actors and public methods, raising this PR to fill the gap.

No issue has been created yet, but open to abandoning this if it doesn't make sense for this adapter.
