### PR TITLE
Refactor HttpRuntime usage to minimize statics usage

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Header.txt
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Header.txt
@@ -17,3 +17,4 @@
 #pragma warning disable CS0809 // Obsolete member overrides non-obsolete member
 #pragma warning disable CA1063 // Implement IDisposable Correctly
 #pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
+

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
@@ -17,6 +17,7 @@
 #pragma warning disable CS0809 // Obsolete member overrides non-obsolete member
 #pragma warning disable CA1063 // Implement IDisposable Correctly
 #pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
+
 namespace System.Web
 {
     public partial class HttpBrowserCapabilities : System.Web.Configuration.HttpCapabilitiesBase
@@ -547,7 +548,7 @@ namespace System.Web.Caching
         public CacheDependency(string[] filenames, System.DateTime start) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public CacheDependency(string[] filenames, string[] cachekeys, System.DateTime start) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public CacheDependency(string[] filenames, string[] cachekeys, System.Web.Caching.CacheDependency dependency, System.DateTime start) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
-        public bool HasChanged { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public bool HasChanged { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public System.DateTime UtcLastModified { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         protected virtual void DependencyDispose() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public void Dispose() { }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/TypeForwards.Framework.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/TypeForwards.Framework.cs
@@ -17,6 +17,7 @@
 #pragma warning disable CS0809 // Obsolete member overrides non-obsolete member
 #pragma warning disable CA1063 // Implement IDisposable Correctly
 #pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
+
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.HttpBrowserCapabilities))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.HttpBrowserCapabilitiesBase))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.HttpBrowserCapabilitiesWrapper))]

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpRuntime.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpRuntime.cs
@@ -9,6 +9,10 @@ public sealed class HttpRuntime
 {
     private static IHttpRuntime? _current;
 
+    /// <summary>
+    /// Gets the current <see cref="IHttpRuntime"/>. This should not be used internally besides where is strictly necessary.
+    /// If this is needed, it should be retrieved through dependency injection.
+    /// </summary>
     internal static IHttpRuntime Current
     {
         get => _current ?? throw new InvalidOperationException("HttpRuntime is not available in the current environment");
@@ -20,7 +24,8 @@ public sealed class HttpRuntime
     }
 
     public static string AppDomainAppVirtualPath => Current.AppDomainAppVirtualPath;
-	public static string AppDomainAppPath => Current.AppDomainAppPath;
 
-    public static System.Web.Caching.Cache Cache => Current.Cache;
+    public static string AppDomainAppPath => Current.AppDomainAppPath;
+
+    public static Caching.Cache Cache => Current.Cache;
 }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/VirtualPathUtility.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/VirtualPathUtility.cs
@@ -1,46 +1,22 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-using System.Text;
 
 namespace System.Web;
 
 /// <summary>
 /// Provides utility methods for common virtual path operations.
 /// </summary>
-/// <remarks>
-/// Portions of this code are based on code originally Copyright (c) 1999 Microsoft Corporation
-/// System.Web.Util.UrlPath code at https://github.com/microsoft/referencesource/blob/master/System.Web/Util/UrlPath.cs
-/// System.Web.Util.StringUtil at https://github.com/microsoft/referencesource/blob/master/System.Web/Util/StringUtil.cs
-/// These files are released under an MIT licence according to https://github.com/microsoft/referencesource#license
-/// </remarks>
 public static class VirtualPathUtility
 {
-
-    #region "Error strings"
-    private const string Empty_path_has_no_directory = "Empty path has no directory.";
-    #endregion
+    private static VirtualPathUtilityImpl Impl { get; } = new VirtualPathUtilityImpl(HttpRuntime.Current);
 
     /// <summary>Appends the literal slash mark (/) to the end of the virtual path, if one does not already exist.</summary>
     /// <returns>The modified virtual path.</returns>
     /// <param name="virtualPath">The virtual path to append the slash mark to.</param>
     [return: NotNullIfNotNull("virtualPath")]
-    public static string? AppendTrailingSlash(string? virtualPath)
-    {
-        if (virtualPath == null) return null;
-
-        var l = virtualPath.Length;
-        if (l == 0) return virtualPath;
-
-        if (virtualPath[l - 1] != '/')
-            virtualPath += '/';
-
-        return virtualPath;
-    }
+    public static string? AppendTrailingSlash(string? virtualPath) => VirtualPathUtilityImpl.AppendTrailingSlash(virtualPath);
 
     /// <summary>Combines a base path and a relative path.</summary>
     /// <returns>The combined <paramref name="basePath" /> and <paramref name="relativePath" />.</returns>
@@ -50,81 +26,42 @@ public static class VirtualPathUtility
     ///   <paramref name="relativePath" /> is a physical path.-or-<paramref name="relativePath" /> includes one or more colons.</exception>
     /// <exception cref="ArgumentNullException">
     ///   <paramref name="relativePath" /> is null or an empty string.-or-<paramref name="basePath" /> is null or an empty string.</exception>
-    public static string Combine(string basePath, string relativePath)
-    {
-        return Util.UrlPath.Combine(HttpRuntime.AppDomainAppVirtualPath, basePath, relativePath);
-    }
+    public static string Combine(string basePath, string relativePath) => Impl.Combine(basePath, relativePath);
 
     /// <summary>Returns the directory portion of a virtual path.</summary>
     /// <returns>The directory referenced in the virtual path. </returns>
     /// <param name="virtualPath">The virtual path.</param>
     /// <exception cref="ArgumentException">
     ///   <paramref name="virtualPath" /> is not rooted. - or -<paramref name="virtualPath" /> is null or an empty string.</exception>
-    public static string? GetDirectory(string virtualPath)
-    {
-        if (string.IsNullOrEmpty(virtualPath))
-            throw new ArgumentNullException(nameof(virtualPath), Empty_path_has_no_directory);
-
-        if (virtualPath[0] != '/' && virtualPath[0] != Util.UrlPath.AppRelativeCharacter)
-            throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, Util.UrlPath.Path_must_be_rooted, virtualPath), nameof(virtualPath));
-
-        if ((virtualPath[0] == Util.UrlPath.AppRelativeCharacter && virtualPath.Length == 1) || virtualPath == Util.UrlPath.AppRelativeCharacterString) return "/";
-        if (virtualPath.Length == 1) return null;
-
-        var slashIndex = virtualPath.LastIndexOf('/');
-
-        // This could happen if the input looks like "~abc"
-        if (slashIndex < 0)
-            throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, Util.UrlPath.Path_must_be_rooted, virtualPath), nameof(virtualPath));
-
-        return virtualPath[..(slashIndex + 1)];
-    }
+    public static string? GetDirectory(string virtualPath) => VirtualPathUtilityImpl.GetDirectory(virtualPath);
 
     /// <summary>Retrieves the extension of the file that is referenced in the virtual path.</summary>
     /// <returns>The file name extension string literal, including the period (.), null, or an empty string ("").</returns>
     /// <param name="virtualPath">The virtual path.</param>
     /// <exception cref="ArgumentException">
-    ///   <paramref name="virtualPath" /> contains one or more characters that are not valid, as defined in <see cref="F:System.IO.Path.InvalidPathChars" />. </exception>
-    public static string? GetExtension(string virtualPath)
-    {
-        if (string.IsNullOrEmpty(virtualPath)) throw new ArgumentNullException(nameof(virtualPath));
-
-        return Util.UrlPath.GetExtension(virtualPath);
-    }
+    ///   <paramref name="virtualPath" /> contains one or more characters that are not valid, as defined in <see cref="IO.Path.InvalidPathChars" />. </exception>
+    public static string? GetExtension(string virtualPath) => VirtualPathUtilityImpl.GetExtension(virtualPath);
 
     /// <summary>Retrieves the file name of the file that is referenced in the virtual path.</summary>
     /// <returns>The file name literal after the last directory character in <paramref name="virtualPath" />; otherwise, the last directory name, if the last character of <paramref name="virtualPath" /> is a directory or volume separator character.</returns>
     /// <param name="virtualPath">The virtual path. </param>
     /// <exception cref="ArgumentException">
-    ///   <paramref name="virtualPath" /> contains one or more characters that are not valid, as defined in <see cref="F:System.IO.Path.InvalidPathChars" />. </exception>
-    public static string? GetFileName(string virtualPath)
-    {
-        if (string.IsNullOrEmpty(virtualPath)) throw new ArgumentNullException(nameof(virtualPath));
-        if (!IsAppRelative(virtualPath) && !Util.UrlPath.IsRooted(virtualPath)) throw new ArgumentException($"The relative virtual path '{virtualPath}' is not allowed here.", nameof(virtualPath));
-        return Util.UrlPath.GetFileName(virtualPath);
-    }
+    ///   <paramref name="virtualPath" /> contains one or more characters that are not valid, as defined in <see cref="IO.Path.InvalidPathChars" />. </exception>
+    public static string? GetFileName(string virtualPath) => VirtualPathUtilityImpl.GetFileName(virtualPath);
 
     /// <summary>Returns a Boolean value indicating whether the specified virtual path is absolute; that is, it starts with a literal slash mark (/).</summary>
     /// <returns>true if <paramref name="virtualPath" /> is an absolute path and is not null or an empty string (""); otherwise, false.</returns>
     /// <param name="virtualPath">The virtual path to check. </param>
     /// <exception cref="ArgumentNullException">
     ///   <paramref name="virtualPath" /> is null.</exception>
-    public static bool IsAbsolute(string virtualPath)
-    {
-        if (string.IsNullOrEmpty(virtualPath)) throw new ArgumentNullException(nameof(virtualPath));
-        return Util.UrlPath.IsRooted(virtualPath);
-    }
+    public static bool IsAbsolute(string virtualPath) => VirtualPathUtilityImpl.IsAbsolute(virtualPath);
 
     /// <summary>Returns a Boolean value indicating whether the specified virtual path is relative to the application.</summary>
     /// <returns>true if <paramref name="virtualPath" /> is relative to the application; otherwise, false.</returns>
     /// <param name="virtualPath">The virtual path to check. </param>
     /// <exception cref="ArgumentNullException">
     ///   <paramref name="virtualPath" /> is null.</exception>
-    public static bool IsAppRelative(string virtualPath)
-    {
-        if (string.IsNullOrEmpty(virtualPath)) throw new ArgumentNullException(nameof(virtualPath));
-        return Util.UrlPath.IsAppRelativePath(virtualPath);
-    }
+    public static bool IsAppRelative(string virtualPath) => VirtualPathUtilityImpl.IsAppRelative(virtualPath);
 
     /// <summary>Returns the relative virtual path from one virtual path containing the root operator (the tilde [~]) to another.</summary>
     /// <returns>The relative virtual path from <paramref name="fromPath" /> to <paramref name="toPath" />.</returns>
@@ -132,18 +69,12 @@ public static class VirtualPathUtility
     /// <param name="toPath">The ending virtual path to return the relative virtual path to.</param>
     /// <exception cref="ArgumentException">
     ///   <paramref name="fromPath" /> is not rooted.- or -<paramref name="toPath" /> is not rooted.</exception>
-    public static string MakeRelative(string fromPath, string toPath) => Util.UrlPath.MakeRelative(fromPath, toPath);
+    public static string MakeRelative(string fromPath, string toPath) => Impl.MakeRelative(fromPath, toPath);
 
     /// <summary>Removes a trailing slash mark (/) from a virtual path.</summary>
     /// <returns>A virtual path without a trailing slash mark, if the virtual path is not already the root directory ("/"); otherwise, null.</returns>
     /// <param name="virtualPath">The virtual path to remove any trailing slash mark from. </param>
-    public static string? RemoveTrailingSlash(string virtualPath)
-    {
-        if (string.IsNullOrEmpty(virtualPath)) return null;
-        var l = virtualPath.Length;
-        if (l <= 1 || virtualPath[l - 1] != '/') return virtualPath;
-        return virtualPath[..(l - 1)];
-    }
+    public static string? RemoveTrailingSlash(string virtualPath) => VirtualPathUtilityImpl.RemoveTrailingSlash(virtualPath);
 
     /// <summary>Converts a virtual path to an application absolute path.</summary>
     /// <returns>The absolute path representation of the specified virtual path. </returns>
@@ -151,12 +82,7 @@ public static class VirtualPathUtility
     /// <exception cref="ArgumentOutOfRangeException">
     ///   <paramref name="virtualPath" /> is not rooted. </exception>
     /// <exception cref="HttpException">A leading double period (..) is used to exit above the top directory.</exception>
-    public static string ToAbsolute(string virtualPath)
-    {
-        if (Util.UrlPath.IsRooted(virtualPath)) return virtualPath;
-        if (IsAppRelative(virtualPath)) return Util.UrlPath.ReduceVirtualPath(Util.UrlPath.MakeVirtualPathAppAbsolute(virtualPath));
-        throw new ArgumentException($"The relative virtual path '{virtualPath}' is not allowed here.", nameof(virtualPath));
-    }
+    public static string ToAbsolute(string virtualPath) => Impl.ToAbsolute(virtualPath);
 
     /// <summary>Converts a virtual path to an application absolute path using the specified application path.</summary>
     /// <returns>The absolute virtual path representation of <paramref name="virtualPath" />.</returns>
@@ -165,55 +91,18 @@ public static class VirtualPathUtility
     /// <exception cref="ArgumentOutOfRangeException">
     ///   <paramref name="applicationPath" /> is not rooted.</exception>
     /// <exception cref="HttpException">A leading double period (..) is used in the application path to exit above the top directory.</exception>
-    public static string ToAbsolute(string virtualPath, string applicationPath)
-    {
-        if (string.IsNullOrEmpty(applicationPath)) throw new ArgumentNullException(nameof(applicationPath));
-        if (!Util.UrlPath.IsRooted(applicationPath)) throw new ArgumentException($"The relative virtual path '{virtualPath}' is not allowed here.", nameof(applicationPath));
-        if (Util.UrlPath.IsRooted(virtualPath)) return virtualPath;
-        var appPath = AppendTrailingSlash(applicationPath);
-        if (IsAppRelative(virtualPath)) return Util.UrlPath.ReduceVirtualPath(Util.UrlPath.MakeVirtualPathAppAbsolute(virtualPath, appPath));
-        throw new ArgumentException($"The relative virtual path '{virtualPath}' is not allowed here.", nameof(virtualPath));
-    }
+    public static string ToAbsolute(string virtualPath, string applicationPath) => Impl.ToAbsolute(virtualPath, applicationPath);
 
-    /// <summary>Converts a virtual path to an application-relative path using the application virtual path that is in the <see cref="P:System.Web.HttpRuntime.AppDomainAppVirtualPath" /> property. </summary>
+    /// <summary>Converts a virtual path to an application-relative path using the application virtual path that is in the <see cref="HttpRuntime.AppDomainAppVirtualPath" /> property. </summary>
     /// <returns>The application-relative path representation of <paramref name="virtualPath" />.</returns>
     /// <param name="virtualPath">The virtual path to convert to an application-relative path. </param>
     /// <exception cref="ArgumentException">
     ///   <paramref name="virtualPath" /> is null. </exception>
-    public static string ToAppRelative(string virtualPath) => ToAppRelative(virtualPath, HttpRuntime.AppDomainAppVirtualPath);
+    public static string ToAppRelative(string virtualPath) => Impl.ToAppRelative(virtualPath);
 
     /// <summary>Converts a virtual path to an application-relative path using a specified application path.</summary>
     /// <returns>The application-relative path representation of <paramref name="virtualPath" />.</returns>
     /// <param name="virtualPath">The virtual path to convert to an application-relative path. </param>
     /// <param name="applicationPath">The application path to use to convert <paramref name="virtualPath" /> to a relative path. </param>
-    public static string ToAppRelative(string virtualPath, string applicationPath)
-    {
-        ArgumentNullException.ThrowIfNull(virtualPath);
-
-        var appPath = AppendTrailingSlash(applicationPath);
-
-        var appPathLength = appPath.Length;
-        var virtualPathLength = virtualPath.Length;
-
-        // If virtualPath is the same as the app path, but without the ending slash,
-        // treat it as if it were truly the app path (VSWhidbey 495949)
-        if (virtualPathLength == appPathLength - 1)
-        {
-            if (Util.StringUtil.StringStartsWithIgnoreCase(appPath, virtualPath))
-                return Util.UrlPath.AppRelativeCharacterString;
-        }
-
-        if (!Util.UrlPath.VirtualPathStartsWithVirtualPath(virtualPath, appPath))
-            return virtualPath;
-
-        // If they are the same, just return "~/"
-        if (virtualPathLength == appPathLength)
-            return Util.UrlPath.AppRelativeCharacterString;
-
-        // Special case for apps rooted at the root:
-        if (appPathLength == 1)
-            return Util.UrlPath.AppRelativeCharacter + virtualPath;
-
-        return Util.UrlPath.AppRelativeCharacter + virtualPath[(appPathLength - 1)..];
-    }
+    public static string ToAppRelative(string virtualPath, string applicationPath) => VirtualPathUtilityImpl.ToAppRelative(virtualPath, applicationPath);
 }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/VirtualPathUtilityImpl.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/VirtualPathUtilityImpl.cs
@@ -1,0 +1,227 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Web.Util;
+using Microsoft.AspNetCore.SystemWebAdapters;
+
+namespace System.Web;
+
+internal sealed class VirtualPathUtilityImpl
+{
+    private const string Empty_path_has_no_directory = "Empty path has no directory.";
+
+    private readonly IHttpRuntime _runtime;
+    private readonly UrlPath _urlPath;
+
+    public VirtualPathUtilityImpl(IHttpRuntime runtime)
+    {
+        _runtime = runtime;
+        _urlPath = new UrlPath(runtime);
+    }
+
+    [return: NotNullIfNotNull("virtualPath")]
+    public static string? AppendTrailingSlash(string? virtualPath)
+    {
+        if (virtualPath == null)
+        {
+            return null;
+        }
+
+        var l = virtualPath.Length;
+        if (l == 0)
+        {
+            return virtualPath;
+        }
+
+        if (virtualPath[l - 1] != '/')
+        {
+            virtualPath += '/';
+        }
+
+        return virtualPath;
+    }
+
+    public string Combine(string basePath, string relativePath)
+        => _urlPath.Combine(_runtime.AppDomainAppVirtualPath, basePath, relativePath);
+
+    public static string? GetDirectory(string virtualPath)
+    {
+        if (string.IsNullOrEmpty(virtualPath))
+        {
+            throw new ArgumentNullException(nameof(virtualPath), Empty_path_has_no_directory);
+        }
+
+        if (virtualPath[0] != '/' && virtualPath[0] != UrlPath.AppRelativeCharacter)
+        {
+            throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, UrlPath.Path_must_be_rooted, virtualPath), nameof(virtualPath));
+        }
+
+        if ((virtualPath[0] == UrlPath.AppRelativeCharacter && virtualPath.Length == 1) || virtualPath == UrlPath.AppRelativeCharacterString)
+        {
+            return "/";
+        }
+
+        if (virtualPath.Length == 1)
+        {
+            return null;
+        }
+
+        var slashIndex = virtualPath.LastIndexOf('/');
+
+        // This could happen if the input looks like "~abc"
+        if (slashIndex < 0)
+        {
+            throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, UrlPath.Path_must_be_rooted, virtualPath), nameof(virtualPath));
+        }
+
+        return virtualPath[..(slashIndex + 1)];
+    }
+
+    public static string? GetExtension(string virtualPath)
+    {
+        if (string.IsNullOrEmpty(virtualPath))
+        {
+            throw new ArgumentNullException(nameof(virtualPath));
+        }
+
+        return UrlPath.GetExtension(virtualPath);
+    }
+
+    public static string? GetFileName(string virtualPath)
+    {
+        if (string.IsNullOrEmpty(virtualPath))
+        {
+            throw new ArgumentNullException(nameof(virtualPath));
+        }
+
+        if (!IsAppRelative(virtualPath) && !UrlPath.IsRooted(virtualPath))
+        {
+            throw new ArgumentException($"The relative virtual path '{virtualPath}' is not allowed here.", nameof(virtualPath));
+        }
+
+        return UrlPath.GetFileName(virtualPath);
+    }
+
+    public static bool IsAbsolute(string virtualPath)
+    {
+        if (string.IsNullOrEmpty(virtualPath))
+        {
+            throw new ArgumentNullException(nameof(virtualPath));
+        }
+
+        return UrlPath.IsRooted(virtualPath);
+    }
+
+    public static bool IsAppRelative(string virtualPath)
+    {
+        if (string.IsNullOrEmpty(virtualPath))
+        {
+            throw new ArgumentNullException(nameof(virtualPath));
+        }
+
+        return UrlPath.IsAppRelativePath(virtualPath);
+    }
+
+    public string MakeRelative(string fromPath, string toPath) => _urlPath.MakeRelative(fromPath, toPath);
+
+    public static string? RemoveTrailingSlash(string virtualPath)
+    {
+        if (string.IsNullOrEmpty(virtualPath))
+        {
+            return null;
+        }
+
+        var l = virtualPath.Length;
+        if (l <= 1 || virtualPath[l - 1] != '/')
+        {
+            return virtualPath;
+        }
+
+        return virtualPath[..(l - 1)];
+    }
+
+    public string ToAbsolute(string virtualPath)
+    {
+        if (UrlPath.IsRooted(virtualPath))
+        {
+            return virtualPath;
+        }
+
+        if (IsAppRelative(virtualPath))
+        {
+            return _urlPath.ReduceVirtualPath(_urlPath.MakeVirtualPathAppAbsolute(virtualPath));
+        }
+
+        throw new ArgumentException($"The relative virtual path '{virtualPath}' is not allowed here.", nameof(virtualPath));
+    }
+
+    public string ToAbsolute(string virtualPath, string applicationPath)
+    {
+        if (string.IsNullOrEmpty(applicationPath))
+        {
+            throw new ArgumentNullException(nameof(applicationPath));
+        }
+
+        if (!UrlPath.IsRooted(applicationPath))
+        {
+            throw new ArgumentException($"The relative virtual path '{virtualPath}' is not allowed here.", nameof(applicationPath));
+        }
+
+        if (UrlPath.IsRooted(virtualPath))
+        {
+            return virtualPath;
+        }
+
+        var appPath = AppendTrailingSlash(applicationPath);
+
+        if (IsAppRelative(virtualPath))
+        {
+            return _urlPath.ReduceVirtualPath(UrlPath.MakeVirtualPathAppAbsolute(virtualPath, appPath));
+        }
+
+        throw new ArgumentException($"The relative virtual path '{virtualPath}' is not allowed here.", nameof(virtualPath));
+    }
+
+    public string ToAppRelative(string virtualPath) => ToAppRelative(virtualPath, _runtime.AppDomainAppVirtualPath);
+
+    public static string ToAppRelative(string virtualPath, string applicationPath)
+    {
+        ArgumentNullException.ThrowIfNull(virtualPath);
+
+        var appPath = AppendTrailingSlash(applicationPath);
+
+        var appPathLength = appPath.Length;
+        var virtualPathLength = virtualPath.Length;
+
+        // If virtualPath is the same as the app path, but without the ending slash,
+        // treat it as if it were truly the app path (VSWhidbey 495949)
+        if (virtualPathLength == appPathLength - 1)
+        {
+            if (StringUtil.StringStartsWithIgnoreCase(appPath, virtualPath))
+            {
+                return UrlPath.AppRelativeCharacterString;
+            }
+        }
+
+        if (!UrlPath.VirtualPathStartsWithVirtualPath(virtualPath, appPath))
+        {
+            return virtualPath;
+        }
+
+        // If they are the same, just return "~/"
+        if (virtualPathLength == appPathLength)
+        {
+            return UrlPath.AppRelativeCharacterString;
+        }
+
+        // Special case for apps rooted at the root:
+        if (appPathLength == 1)
+        {
+            return UrlPath.AppRelativeCharacter + virtualPath;
+        }
+
+        return UrlPath.AppRelativeCharacter + virtualPath[(appPathLength - 1)..];
+    }
+}

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/CacheTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/CacheTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.SystemWebAdapters.Tests
             coreContext.Setup(c => c.RequestServices).Returns(serviceProvider.Object);
 
             var context = new HttpContext(coreContext.Object);
-            
+
             // Act
             var result = context.Cache;
 
@@ -51,43 +51,6 @@ namespace Microsoft.AspNetCore.SystemWebAdapters.Tests
 
             // Act
             var result = contextWrapper.Cache;
-
-            // Assert
-            Assert.Same(cache, result);
-        }
-
-        [Fact]
-        public void CacheFromHttpRuntime()
-        {
-            // Arrange
-            var cache = new Cache();
-
-            var httpRuntime = new Mock<IHttpRuntime>();
-            httpRuntime.Setup(c=>c.Cache).Returns(cache);
-
-            HttpRuntime.Current = httpRuntime.Object;
-
-            // Act
-            var result = System.Web.HttpRuntime.Cache;
-
-            // Assert
-            Assert.Same(cache, result);
-        }
-
-        [Fact]
-        public void CacheFromHttpRuntimeFactory()
-        {
-            // Arrange
-            var cache = new Cache();
-
-            var serviceProvider = new Mock<IServiceProvider>();
-            serviceProvider.Setup(s => s.GetService(typeof(Cache))).Returns(cache);
-
-            var httpRuntime = HttpRuntimeFactory.Create(serviceProvider.Object);
-            HttpRuntime.Current = httpRuntime;
-
-            // Act
-            var result = System.Web.HttpRuntime.Cache;
 
             // Assert
             Assert.Same(cache, result);

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/Internal/NonGenericCollectionWrapperTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/Internal/NonGenericCollectionWrapperTests.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/Internal/NonGenericDictionaryWrapperTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/Internal/NonGenericDictionaryWrapperTests.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/Internal/ServerVariablesNameValueCollectionTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/Internal/ServerVariablesNameValueCollectionTests.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using AutoFixture;
 using Microsoft.AspNetCore.Http.Features;

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/Internal/StringValuesDictionaryNameValueCollectionTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/Internal/StringValuesDictionaryNameValueCollectionTests.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using AutoFixture;
 using Microsoft.Extensions.Primitives;

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/Internal/StringValuesNameValueCollectionTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/Internal/StringValuesNameValueCollectionTests.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Collections;
 using System.Collections.Generic;


### PR DESCRIPTION
In ASP.NET Framework, HttpRuntime was used as a static holder for the runtime information. We expose this type in the adapters, but it should not be accessed directly internally due to its static nature. This currently causes sporadic test failures. Rather, internally should access the IHttpRuntime if this information is needed.

This change includes:

- Changes UrlPath to be a class that takes in the IHttpRuntime
- Moves the logic of VirtualPathUtility into a VirtualPathUtilityImpl that is an instance class
- VirtualPathUtility uses a cached instance of VirtualPathUtilityImpl when needed
- Current usage of VirtualPathUtility in the adapters is replaced with the VirtualPathUtilityImpl
- Tests are updated to no longer require setting HttpRuntime.Current
