### PR TITLE
HttpRequest Params or indexer throws InvalidOperationException when request has content type other than form.

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
@@ -250,6 +250,7 @@ namespace System.Web
         public virtual string ContentType { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual System.Web.HttpCookieCollection Cookies { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual System.Web.HttpFileCollectionBase Files { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public virtual System.Collections.Specialized.NameValueCollection Form { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual System.Collections.Specialized.NameValueCollection Headers { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual string HttpMethod { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual System.IO.Stream InputStream { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
@@ -288,6 +289,7 @@ namespace System.Web
         public override string ContentType { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override System.Web.HttpCookieCollection Cookies { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override System.Web.HttpFileCollectionBase Files { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public override System.Collections.Specialized.NameValueCollection Form { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override System.Collections.Specialized.NameValueCollection Headers { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override string HttpMethod { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override System.IO.Stream InputStream { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpFileCollection.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpFileCollection.cs
@@ -12,6 +12,8 @@ namespace System.Web;
 [SuppressMessage("Design", "CA1010:Collections should implement generic interface", Justification = Constants.ApiFromAspNet)]
 public sealed class HttpFileCollection : NameObjectCollectionBase
 {
+    internal static readonly HttpFileCollection Empty = new(new FormFileCollection());
+
     private string[]? _keys;
 
     internal HttpFileCollection(IFormFileCollection files)

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpRequest.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpRequest.cs
@@ -107,11 +107,11 @@ namespace System.Web
 
         public string RequestType => HttpMethod;
 
-        public NameValueCollection Form => _form ??= _request.Form.ToNameValueCollection();
+        public NameValueCollection Form => _form ??= _request.HasFormContentType ? _request.Form.ToNameValueCollection() : StringValuesReadOnlyDictionaryNameValueCollection.Empty;
 
         public HttpCookieCollection Cookies => _cookies ??= new(_request.Cookies);
 
-        public HttpFileCollection Files => _files ??= new(_request.Form.Files);
+        public HttpFileCollection Files => _files ??= _request.HasFormContentType ? new(_request.Form.Files) : HttpFileCollection.Empty;
 
         public int ContentLength => (int)(_request.ContentLength ?? 0);
 

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpRequestBase.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpRequestBase.cs
@@ -40,6 +40,8 @@ namespace System.Web
 
         public virtual HttpFileCollectionBase Files => throw new NotImplementedException();
 
+        public virtual NameValueCollection Form => throw new NotImplementedException();
+
         public virtual string? this[string key] => throw new NotImplementedException();
 
         public virtual NameValueCollection Params => throw new NotImplementedException();

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpRequestWrapper.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpRequestWrapper.cs
@@ -39,6 +39,8 @@ namespace System.Web
 
         public override HttpFileCollectionBase Files => new HttpFileCollectionWrapper(_request.Files);
 
+        public override NameValueCollection Form => _request.Form;
+
         public override string HttpMethod => _request.HttpMethod;
 
         public override Stream InputStream => _request.InputStream;

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Internal/ParamsCollection.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Internal/ParamsCollection.cs
@@ -35,7 +35,7 @@ internal class ParamsCollection : NoGetByIntNameValueCollection
             return query;
         }
 
-        if (_request.Form.TryGetValue(key, out var form))
+        if (_request.HasFormContentType && _request.Form.TryGetValue(key, out var form))
         {
             return form;
         }

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpRequestTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpRequestTests.cs
@@ -813,6 +813,7 @@ namespace Microsoft.AspNetCore.SystemWebAdapters
             form.Setup(f => f.Count).Returns(0);
 
             var requestCore = new Mock<HttpRequestCore>();
+            requestCore.Setup(r => r.HasFormContentType).Returns(true);
             requestCore.Setup(r => r.Form).Returns(form.Object);
 
             var request = new HttpRequest(requestCore.Object);
@@ -824,6 +825,28 @@ namespace Microsoft.AspNetCore.SystemWebAdapters
             // Assert
             Assert.Same(formCollection1, formCollection2);
             Assert.IsType<StringValuesReadOnlyDictionaryNameValueCollection>(formCollection1);
+        }
+
+        [Fact]
+        public void FormEmptyWithoutFormContentType()
+        {
+            // Arrange
+            var form = new Mock<IFormCollection>();
+            form.Setup(f => f.Count).Returns(0);
+
+            var requestCore = new Mock<HttpRequestCore>();
+            requestCore.Setup(r => r.HasFormContentType).Returns(false);
+            requestCore.Setup(r => r.Form).Throws(new InvalidOperationException("Incorrect Content-Type"));
+
+            var request = new HttpRequest(requestCore.Object);
+
+            // Act
+            var formCollection1 = request.Form;
+            var formCollection2 = request.Form;
+
+            // Assert
+            Assert.Same(formCollection1, formCollection2);
+            Assert.Empty(formCollection1);
         }
 
         [Fact]
@@ -843,6 +866,7 @@ namespace Microsoft.AspNetCore.SystemWebAdapters
             });
 
             var requestCore = new Mock<HttpRequestCore>();
+            requestCore.Setup(r => r.HasFormContentType).Returns(true);
             requestCore.Setup(r => r.Form).Returns(formCollection);
 
             var request = new HttpRequest(requestCore.Object);
@@ -1141,6 +1165,7 @@ namespace Microsoft.AspNetCore.SystemWebAdapters
             form.Setup(f => f.Files).Returns(formFiles.Object);
 
             var requestCore = new Mock<HttpRequestCore>();
+            requestCore.Setup(r => r.HasFormContentType).Returns(true);
             requestCore.Setup(r => r.Form).Returns(form.Object);
 
             var request = new HttpRequest(requestCore.Object);
@@ -1152,6 +1177,25 @@ namespace Microsoft.AspNetCore.SystemWebAdapters
             // Assert
             Assert.Same(files1, files2);
             Assert.Same(files1.FormFiles, formFiles.Object);
+        }
+
+        [Fact]
+        public void FilesEmptyWithoutFormContentType()
+        {
+            // Arrange
+            var requestCore = new Mock<HttpRequestCore>();
+            requestCore.Setup(r => r.HasFormContentType).Returns(false);
+            requestCore.Setup(r => r.Form).Throws(new InvalidOperationException("Incorrect Content-Type"));
+
+            var request = new HttpRequest(requestCore.Object);
+
+            // Act
+            var files1 = request.Files;
+            var files2 = request.Files;
+
+            // Assert
+            Assert.Same(files1, files2);
+            Assert.Empty(files1.FormFiles);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpRequestTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpRequestTests.cs
@@ -932,25 +932,33 @@ namespace Microsoft.AspNetCore.SystemWebAdapters
             ServerVariable,
         }
 
-        [InlineData(ParamSource.None)]
-        [InlineData(ParamSource.Query)]
-        [InlineData(ParamSource.Form)]
-        [InlineData(ParamSource.Cookie)]
-        [InlineData(ParamSource.ServerVariable)]
+        [InlineData(ParamSource.None, false)]
+        [InlineData(ParamSource.Query, false)]
+        [InlineData(ParamSource.Cookie, false)]
+        [InlineData(ParamSource.ServerVariable, false)]
+        [InlineData(ParamSource.None, true)]
+        [InlineData(ParamSource.Query, true)]
+        [InlineData(ParamSource.Form, true)]
+        [InlineData(ParamSource.Cookie, true)]
+        [InlineData(ParamSource.ServerVariable, true)]
         [Theory]
-        public void Indexer(ParamSource source)
-            => GetParam((key, request) => request[key], source);
+        public void Indexer(ParamSource source, bool hasFormContentType)
+            => GetParam((key, request) => request[key], source, hasFormContentType);
 
-        [InlineData(ParamSource.None)]
-        [InlineData(ParamSource.Query)]
-        [InlineData(ParamSource.Form)]
-        [InlineData(ParamSource.Cookie)]
-        [InlineData(ParamSource.ServerVariable)]
+        [InlineData(ParamSource.None, false)]
+        [InlineData(ParamSource.Query, false)]
+        [InlineData(ParamSource.Cookie, false)]
+        [InlineData(ParamSource.ServerVariable, false)]
+        [InlineData(ParamSource.None, true)]
+        [InlineData(ParamSource.Query, true)]
+        [InlineData(ParamSource.Form, true)]
+        [InlineData(ParamSource.Cookie, true)]
+        [InlineData(ParamSource.ServerVariable, true)]
         [Theory]
-        public void Params(ParamSource source)
-            => GetParam((key, request) => request.Params[key], source);
+        public void Params(ParamSource source, bool hasFormContentType)
+            => GetParam((key, request) => request.Params[key], source, hasFormContentType);
 
-        private void GetParam(Func<string, HttpRequest, string?> getParam, ParamSource source)
+        private void GetParam(Func<string, HttpRequest, string?> getParam, ParamSource source, bool hasFormContentType)
         {
             // Arrange
             var key = _fixture.Create<string>();
@@ -1000,8 +1008,17 @@ namespace Microsoft.AspNetCore.SystemWebAdapters
             var requestCore = new Mock<HttpRequestCore>();
             requestCore.Setup(r => r.HttpContext).Returns(contextCore.Object);
             requestCore.Setup(r => r.Query).Returns(queryCollection);
-            requestCore.Setup(r => r.Form).Returns(formCollection);
             requestCore.Setup(r => r.Cookies).Returns(cookies);
+            requestCore.Setup(r => r.HasFormContentType).Returns(hasFormContentType);
+
+            if (hasFormContentType)
+            {
+                requestCore.Setup(r => r.Form).Returns(formCollection);
+            }
+            else
+            {
+                requestCore.Setup(r => r.Form).Throws(new InvalidOperationException("Incorrect Content-Type"));
+            }
 
             var request = new HttpRequest(requestCore.Object);
 


### PR DESCRIPTION
**PR Title**
HttpRequest Params or indexer throws InvalidOperationException when request has content type other than form.

**PR Description**
In the Params or indexer on HttpRequest, do not try to access Form property when request has content type other than form, because this throws an InvalidOperationException

Fixes #309 
