### PR TITLE
Add null checks to wrappers

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpBrowserCapabilitiesWrapper.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpBrowserCapabilitiesWrapper.cs
@@ -9,6 +9,8 @@ public class HttpBrowserCapabilitiesWrapper : HttpBrowserCapabilitiesBase
 
     public HttpBrowserCapabilitiesWrapper(HttpBrowserCapabilities capabilities)
     {
+        ArgumentNullException.ThrowIfNull(capabilities);
+
         _capabilities = capabilities;
     }
 

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpRequestWrapper.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpRequestWrapper.cs
@@ -14,6 +14,8 @@ namespace System.Web
 
         public HttpRequestWrapper(HttpRequest request)
         {
+            ArgumentNullException.ThrowIfNull(request);
+
             _request = request;
         }
 

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponseWrapper.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponseWrapper.cs
@@ -13,6 +13,8 @@ namespace System.Web
 
         public HttpResponseWrapper(HttpResponse response)
         {
+            ArgumentNullException.ThrowIfNull(response);
+
             _response = response;
         }
 

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpServerUtilityWrapper.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpServerUtilityWrapper.cs
@@ -9,6 +9,8 @@ public class HttpServerUtilityWrapper : HttpServerUtilityBase
 
     public HttpServerUtilityWrapper(HttpServerUtility utility)
     {
+        ArgumentNullException.ThrowIfNull(utility);
+
         _utility = utility;
     }
 

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpBrowserCapabilitiesWrapperTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpBrowserCapabilitiesWrapperTests.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Web;
+using Xunit;
+
+namespace Microsoft.AspNetCore.SystemWebAdapters.Tests
+{
+    public class HttpBrowserCapabilitiesWrapperTests
+    {
+        [Fact]
+        public void Constructor()
+        {
+            Assert.Throws<ArgumentNullException>(() => new HttpBrowserCapabilitiesWrapper(null));
+        } 
+    }
+}

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpBrowserCapabilitiesWrapperTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpBrowserCapabilitiesWrapperTests.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.SystemWebAdapters.Tests
         [Fact]
         public void Constructor()
         {
-            Assert.Throws<ArgumentNullException>(() => new HttpBrowserCapabilitiesWrapper(null));
+            Assert.Throws<ArgumentNullException>(() => new HttpBrowserCapabilitiesWrapper(null!));
         } 
     }
 }

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpRequestWrapperTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpRequestWrapperTests.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Web;
+using Xunit;
+
+namespace Microsoft.AspNetCore.SystemWebAdapters.Tests
+{
+    public class HttpRequestWrapperTests
+    {
+        [Fact]
+        public void Constructor()
+        {
+            Assert.Throws<ArgumentNullException>(() => new HttpRequestWrapper(null));
+        } 
+    }
+}

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpRequestWrapperTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpRequestWrapperTests.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.SystemWebAdapters.Tests
         [Fact]
         public void Constructor()
         {
-            Assert.Throws<ArgumentNullException>(() => new HttpRequestWrapper(null));
+            Assert.Throws<ArgumentNullException>(() => new HttpRequestWrapper(null!));
         } 
     }
 }

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpResponseWrapperTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpResponseWrapperTests.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.SystemWebAdapters.Tests
         [Fact]
         public void Constructor()
         {
-            Assert.Throws<ArgumentNullException>(() => new HttpServerUtilityWrapper(null));
+            Assert.Throws<ArgumentNullException>(() => new HttpServerUtilityWrapper(null!));
         } 
     }
 }

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpResponseWrapperTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpResponseWrapperTests.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Web;
+using Xunit;
+
+namespace Microsoft.AspNetCore.SystemWebAdapters.Tests
+{
+    public class HttpServerUtilityWrapperTests
+    {
+        [Fact]
+        public void Constructor()
+        {
+            Assert.Throws<ArgumentNullException>(() => new HttpServerUtilityWrapper(null));
+        } 
+    }
+}

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpServerUtilityWrapperTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpServerUtilityWrapperTests.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.SystemWebAdapters.Tests
         [Fact]
         public void Constructor()
         {
-            Assert.Throws<ArgumentNullException>(() => new HttpResponseWrapper(null));
+            Assert.Throws<ArgumentNullException>(() => new HttpResponseWrapper(null!));
         } 
     }
 }

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpServerUtilityWrapperTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpServerUtilityWrapperTests.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Web;
+using Xunit;
+
+namespace Microsoft.AspNetCore.SystemWebAdapters.Tests
+{
+    public class HttpResponseWrapperTests
+    {
+        [Fact]
+        public void Constructor()
+        {
+            Assert.Throws<ArgumentNullException>(() => new HttpResponseWrapper(null));
+        } 
+    }
+}


### PR DESCRIPTION
**PR Title**
Add null checks to wrappers

**PR Description**
Some Http*Wrapper classes' constructors should check null as they do in .NET Framework. [HttpRequestWrapper for instance](https://referencesource.microsoft.com/#System.Web/Abstractions/HttpRequestWrapper.cs,24).

Fixes #319 
