### PR TITLE
Connect module exception handling to HttpContext

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpApplication/HttpApplicationMiddleware.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpApplication/HttpApplicationMiddleware.cs
@@ -28,6 +28,7 @@ internal class HttpApplicationMiddleware
 
         context.Features.Set<IHttpApplicationFeature>(httpApplicationFeature);
         context.Features.Set<IHttpResponseEndFeature>(httpApplicationFeature);
+        context.Features.Set<IRequestExceptionFeature>(httpApplicationFeature);
 
         try
         {
@@ -48,6 +49,7 @@ internal class HttpApplicationMiddleware
         {
             context.Features.Set<IHttpResponseEndFeature>(endFeature);
             context.Features.Set<IHttpApplicationFeature>(null);
+            context.Features.Set<IRequestExceptionFeature>(null);
 
             _pool.Return(app);
         }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/IRequestExceptionFeature.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/IRequestExceptionFeature.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if NET6_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.SystemWebAdapters;
+
+internal interface IRequestExceptionFeature
+{
+    IReadOnlyList<Exception> Exceptions { get; }
+
+    void Add(Exception exception);
+
+    void Clear();
+}
+#endif

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
@@ -105,11 +105,13 @@ namespace System.Web
     public partial class HttpContext : System.IServiceProvider
     {
         internal HttpContext() { }
+        public System.Exception[] AllErrors { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public System.Web.HttpApplicationState Application { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public System.Web.HttpApplication ApplicationInstance { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public System.Web.Caching.Cache Cache { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public static System.Web.HttpContext Current { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public System.Web.RequestNotification CurrentNotification { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public System.Exception Error { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public bool IsDebuggingEnabled { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public bool IsPostNotification { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public System.Collections.IDictionary Items { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
@@ -119,6 +121,7 @@ namespace System.Web
         public System.Web.SessionState.HttpSessionState Session { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public System.DateTime Timestamp { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public System.Security.Principal.IPrincipal User { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public void AddError(System.Exception ex) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public void ClearError() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public System.Web.ISubscriptionToken DisposeOnPipelineCompleted(System.IDisposable target) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public void RewritePath(string path) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
@@ -127,10 +130,12 @@ namespace System.Web
     public partial class HttpContextBase : System.IServiceProvider
     {
         protected HttpContextBase() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        public virtual System.Exception[] AllErrors { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual System.Web.HttpApplicationState Application { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual System.Web.HttpApplication ApplicationInstance { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual System.Web.Caching.Cache Cache { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual System.Web.RequestNotification CurrentNotification { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public virtual System.Exception Error { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual bool IsDebuggingEnabled { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual bool IsPostNotification { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual System.Collections.IDictionary Items { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
@@ -140,15 +145,19 @@ namespace System.Web
         public virtual System.Web.HttpSessionStateBase Session { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual System.DateTime Timestamp { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual System.Security.Principal.IPrincipal User { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public virtual void AddError(System.Exception ex) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        public virtual void ClearError() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public virtual object GetService(System.Type serviceType) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
     }
     public partial class HttpContextWrapper : System.Web.HttpContextBase
     {
         public HttpContextWrapper(System.Web.HttpContext httpContext) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        public override System.Exception[] AllErrors { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override System.Web.HttpApplicationState Application { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override System.Web.HttpApplication ApplicationInstance { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override System.Web.Caching.Cache Cache { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override System.Web.RequestNotification CurrentNotification { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public override System.Exception Error { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override bool IsDebuggingEnabled { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override bool IsPostNotification { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override System.Collections.IDictionary Items { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
@@ -158,6 +167,8 @@ namespace System.Web
         public override System.Web.HttpSessionStateBase Session { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override System.DateTime Timestamp { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override System.Security.Principal.IPrincipal User { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public override void AddError(System.Exception ex) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        public override void ClearError() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
     }
     public sealed partial class HttpCookie
     {

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpContextBase.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpContextBase.cs
@@ -19,6 +19,16 @@ namespace System.Web
 
         public virtual HttpResponseBase Response => throw new NotImplementedException();
 
+        [SuppressMessage("Naming", "CA1716:Identifiers should not match keywords", Justification = Constants.ApiFromAspNet)]
+        public virtual Exception? Error => throw new NotImplementedException();
+
+        [SuppressMessage("Performance", "CA1819:Properties should not return arrays", Justification = Constants.ApiFromAspNet)]
+        public virtual Exception[] AllErrors => throw new NotImplementedException();
+
+        public virtual void ClearError() => throw new NotImplementedException();
+
+        public virtual void AddError(Exception ex) => throw new NotImplementedException();
+
         public virtual HttpApplication ApplicationInstance => throw new NotImplementedException();
 
         public virtual HttpApplicationState Application => throw new NotImplementedException();

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpContextWrapper.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpContextWrapper.cs
@@ -29,6 +29,14 @@ namespace System.Web
 
         public override bool IsDebuggingEnabled => _context.IsDebuggingEnabled;
 
+        public override void AddError(Exception ex) => _context.AddError(ex);
+
+        public override Exception[] AllErrors => _context.AllErrors;
+
+        public override void ClearError() => _context.ClearError();
+
+        public override Exception? Error => _context.Error;
+
         public override HttpRequestBase Request => _request ??= new HttpRequestWrapper(_context.Request);
 
         public override HttpResponseBase Response => _response ??= new HttpResponseWrapper(_context.Response);

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpServerUtility.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpServerUtility.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
+using System.Linq;
 using Microsoft.AspNetCore.SystemWebAdapters;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -42,12 +43,9 @@ public class HttpServerUtility
             .TrimEnd(Path.DirectorySeparatorChar);
     }
 
-    [Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1024:Use properties where appropriate", Justification = Constants.ApiFromAspNet)]
-    public Exception? GetLastError() => null;
+    public Exception? GetLastError() => _context.GetAdapter().Error;
 
-    public void ClearError()
-    {
-    }
+    public void ClearError() => _context.GetAdapter().ClearError();
 
     /// <summary>
     /// This method is similar to <see cref="WebEncoders.Base64UrlDecode(string)"/> but handles the trailing character that <see cref="UrlTokenEncode(byte[])"/>


### PR DESCRIPTION
HttpContext/HttpServerUtility had methods related to error handling.
When these were added to the adapter, there was no obvious way to
implement them, so they were added as no-ops. However, with module
support, their utility can be implemented as module events was the main
way people interacted with these errors.

Part of #280