### PR TITLE
Support HttpApplication vary-by

### DIFF
--- a/samples/Modules/ModulesCore/Program.cs
+++ b/samples/Modules/ModulesCore/Program.cs
@@ -1,4 +1,5 @@
 using System.Web;
+using Microsoft.AspNetCore.OutputCaching;
 using ModulesLibrary;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -13,9 +14,18 @@ builder.Services.AddSystemWebAdapters()
         options.RegisterModule<EventsModule>("Events");
     });
 
+builder.Services.AddOutputCache(options =>
+{
+    options.AddHttpApplicationBasePolicy(_ => new[] { "browser" });
+});
+
 var app = builder.Build();
 
 app.UseSystemWebAdapters();
+app.UseOutputCache();
+
+app.MapGet("/", () => "Hello")
+    .CacheOutput();
 
 app.Run();
 
@@ -23,5 +33,15 @@ class MyApp : HttpApplication
 {
     protected void Application_Start()
     {
+    }
+
+    public override string? GetVaryByCustomString(System.Web.HttpContext context, string custom)
+    {
+        if (custom == "test")
+        {
+            return "blah";
+        }
+
+        return base.GetVaryByCustomString(context, custom);
     }
 }

--- a/samples/Modules/ModulesLibrary/EventsModule.cs
+++ b/samples/Modules/ModulesLibrary/EventsModule.cs
@@ -17,7 +17,10 @@ namespace ModulesLibrary
                 throw new ArgumentNullException(nameof(context));
             }
 
-            context.Response.ContentType = "text/plain";
+            if (context.CurrentNotification == RequestNotification.BeginRequest)
+            {
+                context.Response.ContentType = "text/plain";
+            }
 
             context.Response.Output.WriteLine(name);
 

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpApplication/HttpApplicationExtensions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpApplication/HttpApplicationExtensions.cs
@@ -58,15 +58,6 @@ public static class HttpApplicationExtensions
         return builder;
     }
 
-    internal static void UseHttpApplication(this IApplicationBuilder app)
-    {
-        if (app.AreHttpApplicationEventsRequired())
-        {
-            app.UseMiddleware<HttpApplicationMiddleware>();
-            app.UseHttpApplicationEvent(ApplicationEvent.BeginRequest);
-        }
-    }
-
     internal static void UseHttpApplicationEvent(this IApplicationBuilder app, params ApplicationEvent[] preEvents)
         => app.UseHttpApplicationEvent(preEvents, Array.Empty<ApplicationEvent>());
 

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpApplication/HttpApplicationOptions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpApplication/HttpApplicationOptions.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Web;
 
 using static System.FormattableString;

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpApplication/HttpApplicationVaryBy.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpApplication/HttpApplicationVaryBy.cs
@@ -1,0 +1,75 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if NET7_0_OR_GREATER
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SystemWebAdapters;
+
+namespace Microsoft.AspNetCore.OutputCaching;
+
+public static class HttpApplicationVaryByExtensions
+{
+    /// <summary>
+    /// Adds a OutputCache policy to the base policy that will query <see cref="System.Web.HttpApplication.GetVaryByCustomString(System.Web.HttpContext, string)"/>
+    /// for values to vary by with the keys supplied by the the <paramref name="keySelector"/>.
+    /// </summary>
+    /// <param name="options">The <see cref="OutputCacheOptions"/> to add the base policy to.</param>
+    /// <param name="keySelector">The selector for keys to query <see cref="System.Web.HttpApplication"/> given the current <see cref="HttpContextCore"/>.</param>
+    public static void AddHttpApplicationBasePolicy(this OutputCacheOptions options, Func<HttpContextCore, IEnumerable<string>> keySelector)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(keySelector);
+
+        options.AddBasePolicy(new HttpApplicationVaryByPolicy(keySelector));
+    }
+
+    /// <summary>
+    /// Adds a named OutputCache policy that will query <see cref="System.Web.HttpApplication.GetVaryByCustomString(System.Web.HttpContext, string)"/>
+    /// for values to vary by with the keys supplied by the the <paramref name="keySelector"/>.
+    /// </summary>
+    /// <param name="options">The <see cref="OutputCacheOptions"/> to add the named policy to.</param>
+    /// <param name="keySelector">The selector for keys to query <see cref="System.Web.HttpApplication"/> given the current <see cref="HttpContextCore"/>.</param>
+    public static void AddHttpApplicationPolicy(this OutputCacheOptions options, string name, Func<HttpContextCore, IEnumerable<string>> keySelector)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(name);
+        ArgumentNullException.ThrowIfNull(keySelector);
+
+        options.AddPolicy(name, new HttpApplicationVaryByPolicy(keySelector));
+    }
+
+    private sealed class HttpApplicationVaryByPolicy : IOutputCachePolicy
+    {
+        private readonly Func<HttpContextCore, IEnumerable<string>> _keySelector;
+
+        public HttpApplicationVaryByPolicy(Func<HttpContextCore, IEnumerable<string>> keySelector)
+        {
+            _keySelector = keySelector;
+        }
+
+        ValueTask IOutputCachePolicy.CacheRequestAsync(OutputCacheContext context, CancellationToken cancellation)
+        {
+            if (context.HttpContext.Features.Get<IHttpApplicationFeature>() is { Application: { } app })
+            {
+                foreach (var key in _keySelector(context.HttpContext))
+                {
+                    context.CacheVaryByRules.VaryByValues[key] = app.GetVaryByCustomString(context.HttpContext, key) ?? string.Empty;
+                }
+            }
+
+            return ValueTask.CompletedTask;
+        }
+
+        ValueTask IOutputCachePolicy.ServeFromCacheAsync(OutputCacheContext context, CancellationToken cancellation)
+            => ValueTask.CompletedTask;
+
+        ValueTask IOutputCachePolicy.ServeResponseAsync(OutputCacheContext context, CancellationToken cancellation)
+            => ValueTask.CompletedTask;
+    }
+}
+#endif
+

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpApplication/HttpApplicationVaryBy.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpApplication/HttpApplicationVaryBy.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.OutputCaching;
 public static class HttpApplicationVaryByExtensions
 {
     /// <summary>
-    /// Adds a OutputCache policy to the base policy that will query <see cref="System.Web.HttpApplication.GetVaryByCustomString(System.Web.HttpContext, string)"/>
+    /// Adds an output cache policy to the base policy that will query <see cref="System.Web.HttpApplication.GetVaryByCustomString(System.Web.HttpContext, string)"/>
     /// for values to vary by with the keys supplied by the the <paramref name="keySelector"/>.
     /// </summary>
     /// <param name="options">The <see cref="OutputCacheOptions"/> to add the base policy to.</param>
@@ -28,7 +28,28 @@ public static class HttpApplicationVaryByExtensions
     }
 
     /// <summary>
-    /// Adds a named OutputCache policy that will query <see cref="System.Web.HttpApplication.GetVaryByCustomString(System.Web.HttpContext, string)"/>
+    /// Adds a collection of custom keys to query <see cref="System.Web.HttpApplication.GetVaryByCustomString(System.Web.HttpContext, string)"/> for values to vary by.
+    /// </summary>
+    /// <param name="builder">The <see cref="OutputCachePolicyBuilder"/> to add the values to.</param>
+    /// <param name="customKeys">The custom keys to vary by value.</param>
+    public static void AddHttpApplicationVaryByCustom(this OutputCachePolicyBuilder builder, params string[] customKeys)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(customKeys);
+
+        foreach (var custom in customKeys)
+        {
+            builder.VaryByValue(context =>
+            {
+                var value = context.Features.Get<IHttpApplicationFeature>()?.Application.GetVaryByCustomString(context, custom);
+
+                return new(custom, value ?? string.Empty);
+            });
+        }
+    }
+
+    /// <summary>
+    /// Adds a named output cache policy that will query <see cref="System.Web.HttpApplication.GetVaryByCustomString(System.Web.HttpContext, string)"/>
     /// for values to vary by with the keys supplied by the the <paramref name="keySelector"/>.
     /// </summary>
     /// <param name="options">The <see cref="OutputCacheOptions"/> to add the named policy to.</param>

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.csproj
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <EnablePackageValidation>true</EnablePackageValidation>
     <RootNamespace>Microsoft.AspNetCore.SystemWebAdapters</RootNamespace>

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/RemoteAppClientPostConfigureOptions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/RemoteAppClientPostConfigureOptions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Extensions.DependencyInjection;
 
 internal class RemoteAppClientPostConfigureOptions : IPostConfigureOptions<RemoteAppClientOptions>
 {
-    public void PostConfigure(string name, RemoteAppClientOptions options)
+    public void PostConfigure(string? name, RemoteAppClientOptions options)
     {
         if (options.BackchannelClient is null)
         {

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/SystemWebAdaptersExtensions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/SystemWebAdaptersExtensions.cs
@@ -44,15 +44,11 @@ public static class SystemWebAdaptersExtensions
             return;
         }
 
-        app.UseMiddleware<RegisterAdapterFeaturesMiddleware>();
         app.UseMiddleware<PreBufferRequestStreamMiddleware>();
         app.UseMiddleware<BufferResponseStreamMiddleware>();
-
         app.UseMiddleware<SetDefaultResponseHeadersMiddleware>();
         app.UseMiddleware<SingleThreadedRequestMiddleware>();
         app.UseMiddleware<CurrentPrincipalMiddleware>();
-
-        app.UseHttpApplication();
     }
 
     public static void UseSystemWebAdapters(this IApplicationBuilder app)
@@ -122,6 +118,13 @@ public static class SystemWebAdaptersExtensions
             => builder =>
             {
                 builder.UseMiddleware<SetHttpContextTimestampMiddleware>();
+                builder.UseMiddleware<RegisterAdapterFeaturesMiddleware>();
+
+                if (builder.AreHttpApplicationEventsRequired())
+                {
+                    builder.UseMiddleware<HttpApplicationMiddleware>();
+                    builder.UseHttpApplicationEvent(ApplicationEvent.BeginRequest);
+                }
 
                 next(builder);
             };

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
@@ -56,6 +56,7 @@ namespace System.Web
         public event System.EventHandler UpdateRequestCache { add { } remove { } }
         public void CompleteRequest() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public void Dispose() { }
+        public virtual string GetVaryByCustomString(System.Web.HttpContext context, string custom) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
     }
     public sealed partial class HttpApplicationState : System.Collections.Specialized.NameObjectCollectionBase
     {

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpApplication.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpApplication.cs
@@ -62,6 +62,16 @@ public class HttpApplication : IDisposable
 
     public void CompleteRequest() => Context.Response.End();
 
+    public virtual string? GetVaryByCustomString(HttpContext context, string custom)
+    {
+        if (string.Equals(custom, "browser", StringComparison.OrdinalIgnoreCase))
+        {
+            return context?.Request.Browser.Type;
+        }
+
+        return null;
+    }
+
     public event EventHandler? BeginRequest
     {
         add => AddEvent(value);


### PR DESCRIPTION
This change adds `HttpApplication.GetVaryByCustomString(context, string custom)`. This API allowed for custom vary by strings given a custom key.

In order to connect that into ASP.NET Core 7+, we can use output caching. To enable this, a selector is required to allow the end user to identify what keys are to be used. For example, on ASP.NET Framework, attributes were used, so on ASP.NET Core a user can grab those attributes from the endpoint metadata collection and collect the keys that way.

For example, they can use the built-in `browser` custom string:

```csharp
builder.Services.AddOutputCache(options =>
{
    options.AddHttpApplicationBasePolicy(_ => new[] { "browser" });
});
```

Fixes #316
