### PR TITLE
Branding update for 1.2-preview.2

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <MajorVersion>1</MajorVersion>
     <MinorVersion>2</MinorVersion>
-    <PreReleaseVersionLabel>preview.1</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>preview.2</PreReleaseVersionLabel>
     <DotNetFinalVersionKind Condition="'$(PreReleaseVersionLabel)' == 'rtw'">release</DotNetFinalVersionKind>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
1.2 preview 1 is now pushed, so bumping prerelease label to preview 2.