### PR TITLE
Handle null session values

### DIFF
--- a/Microsoft.AspNetCore.SystemWebAdapters.sln
+++ b/Microsoft.AspNetCore.SystemWebAdapters.sln
@@ -71,7 +71,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ModulesLibrary", "samples\M
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModulesFramework", "samples\Modules\ModulesFramework\ModulesFramework.csproj", "{B262AD69-11F0-4AE0-949A-AEAA2300C061}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModulesCore", "samples\Modules\ModulesCore\ModulesCore.csproj", "{F8B33C59-27CF-45DC-955C-2EBF9DA9DB7E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ModulesCore", "samples\Modules\ModulesCore\ModulesCore.csproj", "{F8B33C59-27CF-45DC-955C-2EBF9DA9DB7E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Microsoft.AspNetCore.SystemWebAdapters.sln
+++ b/Microsoft.AspNetCore.SystemWebAdapters.sln
@@ -71,7 +71,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ModulesLibrary", "samples\M
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModulesFramework", "samples\Modules\ModulesFramework\ModulesFramework.csproj", "{B262AD69-11F0-4AE0-949A-AEAA2300C061}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ModulesCore", "samples\Modules\ModulesCore\ModulesCore.csproj", "{F8B33C59-27CF-45DC-955C-2EBF9DA9DB7E}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModulesCore", "samples\Modules\ModulesCore\ModulesCore.csproj", "{F8B33C59-27CF-45DC-955C-2EBF9DA9DB7E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/samples/CoreApp/Program.cs
+++ b/samples/CoreApp/Program.cs
@@ -3,11 +3,7 @@ var builder = WebApplication.CreateBuilder();
 builder.Services.AddSystemWebAdapters()
     .WrapAspNetCoreSession()
     .AddSessionSerializer()
-    .AddCustomSerialization()
-    .AddJsonSessionSerializer(options =>
-    {
-        options.RegisterKey<int>("callCount");
-    });
+    .AddCustomSerialization();
 
 builder.Services.AddDistributedMemoryCache();
 

--- a/samples/CoreApp/SessionExampleExtensions.cs
+++ b/samples/CoreApp/SessionExampleExtensions.cs
@@ -10,6 +10,12 @@ internal static class SessionExampleExtensions
 
     public static ISystemWebAdapterBuilder AddCustomSerialization(this ISystemWebAdapterBuilder builder)
     {
+        builder.AddJsonSessionSerializer(options =>
+        {
+            options.RegisterKey<int>("callCount");
+            options.RegisterKey<int?>("item");
+        });
+
         builder.Services.AddSingleton<ISessionKeySerializer>(new ByteArraySerializer(SessionKey));
         return builder;
     }
@@ -59,6 +65,17 @@ internal static class SessionExampleExtensions
 
             return $"This endpoint has been hit {count} time(s) this session";
         });
+
+
+        builder.MapGet("/item", (HttpContextCore ctx) =>
+        {
+            var context = (HttpContext)ctx;
+
+            var result = context.Session!["item"];
+            context.Session!["item"] = default(int);
+
+            return $"Current value: {result}";
+        });
     }
 
     /// <summary>
@@ -88,7 +105,7 @@ internal static class SessionExampleExtensions
             return false;
         }
 
-        public bool TrySerialize(string key, object value, out byte[] bytes)
+        public bool TrySerialize(string key, object? value, out byte[] bytes)
         {
             if (string.Equals(_key, key, StringComparison.Ordinal) && value is byte[] valueBytes)
             {

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.Abstractions/SessionState/Serialization/ISessionKeySerializer.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.Abstractions/SessionState/Serialization/ISessionKeySerializer.cs
@@ -12,7 +12,7 @@ public interface ISessionKeySerializer
     /// <param name="value">Object to serialize.</param>,
     /// <param name="bytes">Bytes if successful.</param>
     /// <returns><c>true</c> if successful. If key is unknown, <c>false</c> will be returned.</returns>
-    bool TrySerialize(string key, object value, out byte[] bytes);
+    bool TrySerialize(string key, object? value, out byte[] bytes);
 
     /// <summary>
     /// Deserializes a session object for a given key.

--- a/src/Services/SessionState/BinarySessionSerializer.cs
+++ b/src/Services/SessionState/BinarySessionSerializer.cs
@@ -162,10 +162,7 @@ internal partial class BinarySessionSerializer : ISessionSerializer
 
                 if (serializer.TryDeserialize(key, bytes, out var result))
                 {
-                    if (result is not null)
-                    {
-                        this[key] = result;
-                    }
+                    this[key] = result;
                 }
                 else
                 {

--- a/src/Services/SessionState/CompositeSessionKeySerializer.cs
+++ b/src/Services/SessionState/CompositeSessionKeySerializer.cs
@@ -13,7 +13,7 @@ internal sealed class CompositeSessionKeySerializer : ICompositeSessionKeySerial
         _serializers = serializers.ToArray();
     }
 
-    public bool TrySerialize(string key, object value, out byte[] bytes)
+    public bool TrySerialize(string key, object? value, out byte[] bytes)
     {
         foreach (var serializer in _serializers)
         {

--- a/src/Services/SessionState/JsonSessionKeySerializer.cs
+++ b/src/Services/SessionState/JsonSessionKeySerializer.cs
@@ -22,7 +22,6 @@ internal partial class JsonSessionKeySerializer : ISessionKeySerializer
     [LoggerMessage(0, LogLevel.Error, "Unexpected JSON serialize/deserialization error for '{Key}' expected type '{Type}'")]
     private partial void LogException(Exception e, string key, string type);
 
-
     [LoggerMessage(1, LogLevel.Warning, "Session key '{Key}' is registered as {RegisteredType} but was actually {FoundType}")]
     private partial void UnexpectedType(string key, Type registeredType, Type foundType);
 

--- a/src/Services/SessionState/JsonSessionKeySerializer.cs
+++ b/src/Services/SessionState/JsonSessionKeySerializer.cs
@@ -51,14 +51,14 @@ internal partial class JsonSessionKeySerializer : ISessionKeySerializer
         {
             if (value is null)
             {
-                if (!type.IsValueType || (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>)))
+                if (!type.IsValueType || IsNullable(type))
                 {
                     // Create a new one instead of caching since technically the array values could be overwritten
                     bytes = "null"u8.ToArray();
                     return true;
                 }
             }
-            else if (type == value.GetType() || (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>) && type.GenericTypeArguments[0] == value.GetType()))
+            else if (type == value.GetType() || IsNullableType(type, value.GetType()))
             {
                 try
                 {
@@ -79,5 +79,11 @@ internal partial class JsonSessionKeySerializer : ISessionKeySerializer
         bytes = Array.Empty<byte>();
         return false;
     }
+
+    private static bool IsNullable(Type type)
+        => type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
+
+    private static bool IsNullableType(Type type, Type nullableArg)
+        => IsNullable(type) && nullableArg == type.GenericTypeArguments[0];
 }
 

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/SessionState/Serialization/BinarySessionSerializerTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/SessionState/Serialization/BinarySessionSerializerTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -29,14 +27,14 @@ public class BinarySessionSerializerTests
         await serializer.SerializeAsync(state.Object, ms, default);
 
         // Assert
-        Assert.Equal(ms.ToArray(), new byte[] { 2, 2, 105, 100, 0, 0, 0, 0, 0, 0 });
+        Assert.Equal(ms.ToArray(), new byte[] { 1, 2, 105, 100, 0, 0, 0, 0, 0, 0 });
     }
 
     [Fact]
     public async Task DeserializeEmpty()
     {
         // Arrange
-        var data = new byte[] { 2, 2, 105, 100, 0, 0, 0, 0, 0, 0 };
+        var data = new byte[] { 1, 2, 105, 100, 0, 0, 0, 0, 0, 0 };
         using var ms = new MemoryStream(data);
 
         var serializer = CreateSerializer();
@@ -69,14 +67,14 @@ public class BinarySessionSerializerTests
         await serializer.SerializeAsync(state.Object, ms, default);
 
         // Assert
-        Assert.Equal(ms.ToArray(), new byte[] { 2, 2, 105, 100, 1, 0, 0, 0, 0, 0 });
+        Assert.Equal(ms.ToArray(), new byte[] { 1, 2, 105, 100, 1, 0, 0, 0, 0, 0 });
     }
 
     [Fact]
     public async Task DeserializeIsNewSession()
     {
         // Arrange
-        var data = new byte[] { 2, 2, 105, 100, 1, 0, 0, 0, 0, 0 };
+        var data = new byte[] { 1, 2, 105, 100, 1, 0, 0, 0, 0, 0 };
         using var ms = new MemoryStream(data);
 
         var serializer = CreateSerializer();
@@ -109,14 +107,14 @@ public class BinarySessionSerializerTests
         await serializer.SerializeAsync(state.Object, ms, default);
 
         // Assert
-        Assert.Equal(ms.ToArray(), new byte[] { 2, 2, 105, 100, 0, 1, 0, 0, 0, 0 });
+        Assert.Equal(ms.ToArray(), new byte[] { 1, 2, 105, 100, 0, 1, 0, 0, 0, 0 });
     }
 
     [Fact]
     public async Task DeserializeIsAbandoned()
     {
         // Arrange
-        var data = new byte[] { 2, 2, 105, 100, 0, 1, 0, 0, 0, 0 };
+        var data = new byte[] { 1, 2, 105, 100, 0, 1, 0, 0, 0, 0 };
         using var ms = new MemoryStream(data);
 
         var serializer = CreateSerializer();
@@ -149,14 +147,14 @@ public class BinarySessionSerializerTests
         await serializer.SerializeAsync(state.Object, ms, default);
 
         // Assert
-        Assert.Equal(ms.ToArray(), new byte[] { 2, 2, 105, 100, 0, 0, 1, 0, 0, 0 });
+        Assert.Equal(ms.ToArray(), new byte[] { 1, 2, 105, 100, 0, 0, 1, 0, 0, 0 });
     }
 
     [Fact]
     public async Task DeserializeIsReadOnly()
     {
         // Arrange
-        var data = new byte[] { 2, 2, 105, 100, 0, 0, 1, 0, 0, 0 };
+        var data = new byte[] { 1, 2, 105, 100, 0, 0, 1, 0, 0, 0 };
         using var ms = new MemoryStream(data);
 
         var serializer = CreateSerializer();
@@ -175,7 +173,7 @@ public class BinarySessionSerializerTests
     }
 
     [Fact]
-    public async Task DeserializeIsReadOnlyV1()
+    public async Task DeserializeIsReadOnlyEmptyNull()
     {
         // Arrange
         var data = new byte[] { 1, 2, 105, 100, 0, 0, 1, 0, 0, 0 };
@@ -211,14 +209,14 @@ public class BinarySessionSerializerTests
         await serializer.SerializeAsync(state.Object, ms, default);
 
         // Assert
-        Assert.Equal(ms.ToArray(), new byte[] { 2, 2, 105, 100, 0, 0, 0, 20, 0, 0 });
+        Assert.Equal(ms.ToArray(), new byte[] { 1, 2, 105, 100, 0, 0, 0, 20, 0, 0 });
     }
 
     [Fact]
     public async Task DeserializeTimeout()
     {
         // Arrange
-        var data = new byte[] { 2, 2, 105, 100, 0, 0, 0, 20, 0, 0 };
+        var data = new byte[] { 1, 2, 105, 100, 0, 0, 0, 20, 0, 0 };
         using var ms = new MemoryStream(data);
 
         var serializer = CreateSerializer();
@@ -258,7 +256,7 @@ public class BinarySessionSerializerTests
         await serializer.SerializeAsync(state.Object, ms, default);
 
         // Assert
-        Assert.Equal(ms.ToArray(), new byte[] { 2, 2, 105, 100, 0, 0, 0, 0, 1, 4, 107, 101, 121, 49, 1, 42, 0 });
+        Assert.Equal(ms.ToArray(), new byte[] { 1, 2, 105, 100, 0, 0, 0, 0, 1, 4, 107, 101, 121, 49, 1, 42, 0 });
     }
 
     [Fact]
@@ -283,14 +281,14 @@ public class BinarySessionSerializerTests
         await serializer.SerializeAsync(state.Object, ms, default);
 
         // Assert
-        Assert.Equal(ms.ToArray(), new byte[] { 2, 2, 105, 100, 0, 0, 0, 0, 1, 4, 107, 101, 121, 49, 1, 0, 0 });
+        Assert.Equal(ms.ToArray(), new byte[] { 1, 2, 105, 100, 0, 0, 0, 0, 1, 4, 107, 101, 121, 49, 1, 0, 0 });
     }
 
     [Fact]
     public async Task Deserialize1KeyNull()
     {
         // Arrange
-        var data = new byte[] { 2, 2, 105, 100, 0, 0, 0, 0, 1, 4, 107, 101, 121, 49, 1, 0, 0 };
+        var data = new byte[] { 1, 2, 105, 100, 0, 0, 0, 0, 1, 4, 107, 101, 121, 49, 1, 0, 0 };
         var obj = new object();
         var value = new byte[] { 0 };
 
@@ -362,7 +360,7 @@ public class BinarySessionSerializerTests
         await serializer.SerializeAsync(state.Object, ms, default);
 
         // Assert
-        Assert.Equal(ms.ToArray(), new byte[] { 2, 2, 105, 100, 0, 0, 0, 0, 1, 4, 107, 101, 121, 49, 1, 0, 0 });
+        Assert.Equal(ms.ToArray(), new byte[] { 1, 2, 105, 100, 0, 0, 0, 0, 1, 4, 107, 101, 121, 49, 1, 0, 0 });
     }
 
     [Fact]
@@ -374,7 +372,7 @@ public class BinarySessionSerializerTests
         var keySerializer = new Mock<ISessionKeySerializer>();
         keySerializer.Setup(k => k.TryDeserialize("key1", bytes, out obj)).Returns(true);
 
-        var data = new byte[] { 2, 2, 105, 100, 0, 0, 0, 0, 1, 4, 107, 101, 121, 49, 1, 42, 0 };
+        var data = new byte[] { 1, 2, 105, 100, 0, 0, 0, 0, 1, 4, 107, 101, 121, 49, 1, 42, 0 };
         using var ms = new MemoryStream(data);
 
         var serializer = CreateSerializer(keySerializer.Object);
@@ -398,9 +396,8 @@ public class BinarySessionSerializerTests
         keySerializer ??= new Mock<ISessionKeySerializer>().Object;
         var logger = new Mock<ILogger<BinarySessionSerializer>>();
 
-        var options = new SessionSerializerOptions();
         var optionContainer = new Mock<IOptions<SessionSerializerOptions>>();
-        optionContainer.Setup(o => o.Value).Returns(options);
+        optionContainer.Setup(o => o.Value).Returns(new SessionSerializerOptions());
 
         return new BinarySessionSerializer(new Composite(keySerializer), optionContainer.Object, logger.Object);
     }

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/SessionState/Serialization/BinarySessionSerializerTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/SessionState/Serialization/BinarySessionSerializerTests.cs
@@ -29,14 +29,14 @@ public class BinarySessionSerializerTests
         await serializer.SerializeAsync(state.Object, ms, default);
 
         // Assert
-        Assert.Equal(ms.ToArray(), new byte[] { 1, 2, 105, 100, 0, 0, 0, 0, 0, 0 });
+        Assert.Equal(ms.ToArray(), new byte[] { 2, 2, 105, 100, 0, 0, 0, 0, 0, 0 });
     }
 
     [Fact]
     public async Task DeserializeEmpty()
     {
         // Arrange
-        var data = new byte[] { 1, 2, 105, 100, 0, 0, 0, 0, 0, 0 };
+        var data = new byte[] { 2, 2, 105, 100, 0, 0, 0, 0, 0, 0 };
         using var ms = new MemoryStream(data);
 
         var serializer = CreateSerializer();
@@ -69,14 +69,14 @@ public class BinarySessionSerializerTests
         await serializer.SerializeAsync(state.Object, ms, default);
 
         // Assert
-        Assert.Equal(ms.ToArray(), new byte[] { 1, 2, 105, 100, 1, 0, 0, 0, 0, 0 });
+        Assert.Equal(ms.ToArray(), new byte[] { 2, 2, 105, 100, 1, 0, 0, 0, 0, 0 });
     }
 
     [Fact]
     public async Task DeserializeIsNewSession()
     {
         // Arrange
-        var data = new byte[] { 1, 2, 105, 100, 1, 0, 0, 0, 0, 0 };
+        var data = new byte[] { 2, 2, 105, 100, 1, 0, 0, 0, 0, 0 };
         using var ms = new MemoryStream(data);
 
         var serializer = CreateSerializer();
@@ -109,14 +109,14 @@ public class BinarySessionSerializerTests
         await serializer.SerializeAsync(state.Object, ms, default);
 
         // Assert
-        Assert.Equal(ms.ToArray(), new byte[] { 1, 2, 105, 100, 0, 1, 0, 0, 0, 0 });
+        Assert.Equal(ms.ToArray(), new byte[] { 2, 2, 105, 100, 0, 1, 0, 0, 0, 0 });
     }
 
     [Fact]
     public async Task DeserializeIsAbandoned()
     {
         // Arrange
-        var data = new byte[] { 1, 2, 105, 100, 0, 1, 0, 0, 0, 0 };
+        var data = new byte[] { 2, 2, 105, 100, 0, 1, 0, 0, 0, 0 };
         using var ms = new MemoryStream(data);
 
         var serializer = CreateSerializer();
@@ -149,11 +149,33 @@ public class BinarySessionSerializerTests
         await serializer.SerializeAsync(state.Object, ms, default);
 
         // Assert
-        Assert.Equal(ms.ToArray(), new byte[] { 1, 2, 105, 100, 0, 0, 1, 0, 0, 0 });
+        Assert.Equal(ms.ToArray(), new byte[] { 2, 2, 105, 100, 0, 0, 1, 0, 0, 0 });
     }
 
     [Fact]
     public async Task DeserializeIsReadOnly()
+    {
+        // Arrange
+        var data = new byte[] { 2, 2, 105, 100, 0, 0, 1, 0, 0, 0 };
+        using var ms = new MemoryStream(data);
+
+        var serializer = CreateSerializer();
+
+        // Act
+        var result = await serializer.DeserializeAsync(ms, default);
+
+        // Assert
+        Assert.Equal("id", result!.SessionID);
+        Assert.True(result.IsReadOnly);
+        Assert.False(result.IsAbandoned);
+        Assert.False(result.IsNewSession);
+        Assert.Equal(0, result.Timeout);
+        Assert.Equal(0, result.Count);
+        Assert.Empty(result.Keys);
+    }
+
+    [Fact]
+    public async Task DeserializeIsReadOnlyV1()
     {
         // Arrange
         var data = new byte[] { 1, 2, 105, 100, 0, 0, 1, 0, 0, 0 };
@@ -189,14 +211,14 @@ public class BinarySessionSerializerTests
         await serializer.SerializeAsync(state.Object, ms, default);
 
         // Assert
-        Assert.Equal(ms.ToArray(), new byte[] { 1, 2, 105, 100, 0, 0, 0, 20, 0, 0 });
+        Assert.Equal(ms.ToArray(), new byte[] { 2, 2, 105, 100, 0, 0, 0, 20, 0, 0 });
     }
 
     [Fact]
     public async Task DeserializeTimeout()
     {
         // Arrange
-        var data = new byte[] { 1, 2, 105, 100, 0, 0, 0, 20, 0, 0 };
+        var data = new byte[] { 2, 2, 105, 100, 0, 0, 0, 20, 0, 0 };
         using var ms = new MemoryStream(data);
 
         var serializer = CreateSerializer();
@@ -236,7 +258,84 @@ public class BinarySessionSerializerTests
         await serializer.SerializeAsync(state.Object, ms, default);
 
         // Assert
-        Assert.Equal(ms.ToArray(), new byte[] { 1, 2, 105, 100, 0, 0, 0, 0, 1, 4, 107, 101, 121, 49, 1, 42, 0 });
+        Assert.Equal(ms.ToArray(), new byte[] { 2, 2, 105, 100, 0, 0, 0, 0, 1, 4, 107, 101, 121, 49, 1, 42, 0 });
+    }
+
+    [Fact]
+    public async Task Serialize1KeyNull()
+    {
+        // Arrange
+        var obj = default(object);
+        var state = new Mock<ISessionState>();
+        state.Setup(s => s["key1"]).Returns(obj);
+        state.Setup(s => s.SessionID).Returns("id");
+        state.Setup(s => s.Keys).Returns(new[] { "key1" });
+        state.Setup(s => s.Count).Returns(1);
+
+        var keySerializer = new Mock<ISessionKeySerializer>();
+        var bytes = new byte[] { 0 };
+        keySerializer.Setup(k => k.TrySerialize("key1", obj, out bytes)).Returns(true);
+
+        var serializer = CreateSerializer(keySerializer.Object);
+        using var ms = new MemoryStream();
+
+        // Act
+        await serializer.SerializeAsync(state.Object, ms, default);
+
+        // Assert
+        Assert.Equal(ms.ToArray(), new byte[] { 2, 2, 105, 100, 0, 0, 0, 0, 1, 4, 107, 101, 121, 49, 1, 0, 0 });
+    }
+
+    [Fact]
+    public async Task Deserialize1KeyV1()
+    {
+        // Arrange
+        var obj = new object();
+        var keySerializer = new Mock<ISessionKeySerializer>();
+        keySerializer.Setup(k => k.TryDeserialize("key1", Array.Empty<byte>(), out obj)).Returns(true);
+
+        var data = new byte[] { 1, 2, 105, 100, 0, 0, 0, 0, 1, 4, 107, 101, 121, 49, 0, 0 };
+        using var ms = new MemoryStream(data);
+
+        var serializer = CreateSerializer(keySerializer.Object);
+
+        // Act
+        var result = await serializer.DeserializeAsync(ms, default);
+
+        // Assert
+        Assert.Equal("id", result!.SessionID);
+        Assert.False(result.IsReadOnly);
+        Assert.False(result.IsAbandoned);
+        Assert.False(result.IsNewSession);
+        Assert.Equal(0, result.Timeout);
+        Assert.Equal(1, result.Count);
+        Assert.Equal(result.Keys, new[] { "key1" });
+        Assert.Equal(obj, result["key1"]);
+    }
+
+    [Fact]
+    public async Task Serialize1KeyNullable()
+    {
+        // Arrange
+        var obj = (int?)5;
+        var state = new Mock<ISessionState>();
+        state.Setup(s => s["key1"]).Returns(obj);
+        state.Setup(s => s.SessionID).Returns("id");
+        state.Setup(s => s.Keys).Returns(new[] { "key1" });
+        state.Setup(s => s.Count).Returns(1);
+
+        var keySerializer = new Mock<ISessionKeySerializer>();
+        var bytes = new byte[] { 0 };
+        keySerializer.Setup(k => k.TrySerialize("key1", obj, out bytes)).Returns(true);
+
+        var serializer = CreateSerializer(keySerializer.Object);
+        using var ms = new MemoryStream();
+
+        // Act
+        await serializer.SerializeAsync(state.Object, ms, default);
+
+        // Assert
+        Assert.Equal(ms.ToArray(), new byte[] { 2, 2, 105, 100, 0, 0, 0, 0, 1, 4, 107, 101, 121, 49, 1, 0, 0 });
     }
 
     [Fact]
@@ -248,7 +347,7 @@ public class BinarySessionSerializerTests
         var keySerializer = new Mock<ISessionKeySerializer>();
         keySerializer.Setup(k => k.TryDeserialize("key1", bytes, out obj)).Returns(true);
 
-        var data = new byte[] { 1, 2, 105, 100, 0, 0, 0, 0, 1, 4, 107, 101, 121, 49, 1, 42, 0 };
+        var data = new byte[] { 2, 2, 105, 100, 0, 0, 0, 0, 1, 4, 107, 101, 121, 49, 1, 42, 0 };
         using var ms = new MemoryStream(data);
 
         var serializer = CreateSerializer(keySerializer.Object);
@@ -272,8 +371,9 @@ public class BinarySessionSerializerTests
         keySerializer ??= new Mock<ISessionKeySerializer>().Object;
         var logger = new Mock<ILogger<BinarySessionSerializer>>();
 
+        var options = new SessionSerializerOptions();
         var optionContainer = new Mock<IOptions<SessionSerializerOptions>>();
-        optionContainer.Setup(o => o.Value).Returns(new SessionSerializerOptions());
+        optionContainer.Setup(o => o.Value).Returns(options);
 
         return new BinarySessionSerializer(new Composite(keySerializer), optionContainer.Object, logger.Object);
     }
@@ -290,7 +390,7 @@ public class BinarySessionSerializerTests
         public bool TryDeserialize(string key, byte[] bytes, out object? obj)
             => _serializer.TryDeserialize(key, bytes, out obj);
 
-        public bool TrySerialize(string key, object value, out byte[] bytes)
+        public bool TrySerialize(string key, object? value, out byte[] bytes)
             => _serializer.TrySerialize(key, value, out bytes);
     }
 }

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/SessionState/Serialization/BinarySessionSerializerTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/SessionState/Serialization/BinarySessionSerializerTests.cs
@@ -287,6 +287,33 @@ public class BinarySessionSerializerTests
     }
 
     [Fact]
+    public async Task Deserialize1KeyNull()
+    {
+        // Arrange
+        var data = new byte[] { 2, 2, 105, 100, 0, 0, 0, 0, 1, 4, 107, 101, 121, 49, 1, 0, 0 };
+        var obj = new object();
+        var value = new byte[] { 0 };
+
+        var keySerializer = new Mock<ISessionKeySerializer>();
+        keySerializer.Setup(k => k.TryDeserialize("key1", value, out obj)).Returns(true);
+
+        var serializer = CreateSerializer(keySerializer.Object);
+
+        // Act
+        var result = await serializer.DeserializeAsync(new MemoryStream(data), default);
+
+        // Assert
+        Assert.Equal("id", result!.SessionID);
+        Assert.False(result.IsReadOnly);
+        Assert.False(result.IsAbandoned);
+        Assert.False(result.IsNewSession);
+        Assert.Equal(0, result.Timeout);
+        Assert.Equal(1, result.Count);
+        Assert.Same(obj, result["key1"]);
+        Assert.Collection(result.Keys, k => Assert.Equal("key1", k));
+    }
+
+    [Fact]
     public async Task Deserialize1KeyV1()
     {
         // Arrange

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/SessionState/Wrapped/AspNetCoreSessionState.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/SessionState/Wrapped/AspNetCoreSessionState.cs
@@ -301,7 +301,7 @@ public class AspNetCoreSessionStateTests
         public bool TryDeserialize(string key, byte[] bytes, out object? obj)
             => _serializer.TryDeserialize(key, bytes, out obj);
 
-        public bool TrySerialize(string key, object value, out byte[] bytes)
+        public bool TrySerialize(string key, object? value, out byte[] bytes)
             => _serializer.TrySerialize(key, value, out bytes);
     }
 }

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices.Tests/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices.Tests.csproj
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices.Tests/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices.Tests.csproj
@@ -4,6 +4,10 @@
     <RootNamespace>Microsoft.AspNetCore.SystemWebAdapters.Tests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests\SessionState\Serialization\BinarySessionSerializerTests.cs" Link="SessionState\BinarySessionSerializerTests.cs" />
+    <Compile Include="..\Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests\SessionState\Serialization\JsonSessionKeySerializerTests.cs" Link="SessionState\JsonSessionKeySerializerTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Autofac.Extras.Moq" Version="6.0.0" />
     <PackageReference Include="AutoFixture" Version="4.15.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
@@ -16,5 +20,8 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Web" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="SessionState\" />
   </ItemGroup>
 </Project>

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices.Tests/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices.Tests.csproj
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices.Tests/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices.Tests.csproj
@@ -21,7 +21,4 @@
   <ItemGroup>
     <Reference Include="System.Web" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="SessionState\" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
This change does the following to handle null values (including nullable structs):

1. Allow null values to be passed into ISessionKeySerializer.TrySerialize
2. Check if null (or if Nullable<>) and serialize it
3. Remove special casing of null values in the SessionState default serializer (BinarySessionSerializer)

Fixes #346 
