### PR TITLE
Add support for HtmlString and IHtmlString

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/ExcludedApis.txt
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/ExcludedApis.txt
@@ -17,3 +17,9 @@ T:System.Web.SameSiteMode
 
 T:Microsoft.AspNetCore.SystemWebAdapters.IBrowserCapabilitiesFactory
 T:Microsoft.AspNetCore.SystemWebAdapters.IHttpBrowserCapabilityFeature
+
+# We provide implementations of this on .NET Standard 2.0 and .NET 6.0
+T:System.Web.IHtmlString
+
+# We implement extra interfaces that end up getting added to the generated stuff
+T:System.Web.HtmlString

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HtmlString.IHtmlContent.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HtmlString.IHtmlContent.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if NET6_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Html;
+
+using CoreHtmlString = Microsoft.AspNetCore.Html.HtmlString;
+
+namespace System.Web;
+
+public partial class HtmlString : IHtmlContent
+{
+    [SuppressMessage("Design", "CA1033:Interface methods should be callable by child types", Justification = Constants.ApiFromAspNet)]
+    void IHtmlContent.WriteTo(TextWriter writer, HtmlEncoder encoder)
+    {
+        writer.Write(_htmlString);
+    }
+
+    [return: NotNullIfNotNull(nameof(other))]
+    public static implicit operator HtmlString?(CoreHtmlString? other)
+       => other is null ? null : new(other.Value ?? string.Empty);
+
+    [return: NotNullIfNotNull(nameof(other))]
+    public static implicit operator CoreHtmlString?(HtmlString? other)
+       => other is null ? null : new(other._htmlString);
+}
+#endif

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HtmlString.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HtmlString.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if NETFRAMEWORK
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.HtmlString))]
+#else
+namespace System.Web;
+
+public partial class HtmlString : IHtmlString
+{
+    private readonly string _htmlString;
+
+    public HtmlString(string value) => _htmlString = value;
+
+    public string ToHtmlString() => _htmlString;
+
+    public override string ToString() => _htmlString;
+}
+#endif

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/IHtmlString.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/IHtmlString.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// This is available in-box in .NET Framework and .NET 8+. We type forward to that when possible, otherwise, provide an implementation here for compat purposes.
+#if NETSTANDARD || NET6_0
+
+namespace System.Web;
+
+public interface IHtmlString
+{
+    string ToHtmlString();
+}
+
+#else
+
+[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.IHtmlString))]
+
+#endif

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Microsoft.AspNetCore.SystemWebAdapters.csproj
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Microsoft.AspNetCore.SystemWebAdapters.csproj
@@ -28,6 +28,8 @@
     <Compile Include="Properties/PropertyInfo.cs" />
     <Compile Include="Generated/Ref.*.cs" />
     <Compile Include="Adapters/SessionState/ISessionState.cs" />
+    <Compile Include="IHtmlString.cs" />
+    <Compile Include="HtmlString.cs" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
@@ -44,6 +46,9 @@
     <Compile Include="Properties/PropertyInfo.cs" />
     <Compile Include="Adapters/**/*.cs" />
     <Compile Include="Generated/TypeForwards.*.cs" />
+
+    <Compile Include="IHtmlString.cs" />
+    <Compile Include="HtmlString.cs" />
 
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
IHtmlString has been added to .NET 8 in box, but not the HtmlString
implementation. This means we will have both types here, but forward
when possible to in-box versions:

- On .NET Framework, both are type forwarded
- On .NET 8+, IHtmlString will be type forwarded
- Otherwise, both implementations with live in the adapters

This will allow users to compikle against .NET Standard, and have
expected behavior light up on the platforms that support it.
