### PR TITLE
Forward IHtmlString on .NET 8

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Configuration/BrowserCapabilitiesFactory.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Configuration/BrowserCapabilitiesFactory.cs
@@ -47,7 +47,7 @@ internal sealed class BrowserCapabilitiesFactory : IBrowserCapabilitiesFactory
 
     IHttpBrowserCapabilityFeature IBrowserCapabilitiesFactory.Create(HttpRequestCore request)
     {
-        var userAgent = request.Headers.UserAgent;
+        var userAgent = request.Headers.UserAgent.ToString();
 
         if (string.IsNullOrWhiteSpace(userAgent))
         {
@@ -60,7 +60,7 @@ internal sealed class BrowserCapabilitiesFactory : IBrowserCapabilitiesFactory
                 entry.SlidingExpiration = TimeSpan.FromMinutes(2);
 
                 return Parse(userAgent);
-            });
+            }) ?? EmptyBrowserFeatures.Instance;
         }
         else
         {

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpRequest.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpRequest.cs
@@ -89,7 +89,10 @@ namespace System.Web
 
                         for (var i = 0; i < length; i++)
                         {
-                            userLanguages[i] = qualityArray[i].Value.Value;
+                            if (qualityArray[i].Value.Value is { } language)
+                            {
+                                userLanguages[i] = language;
+                            }
                         }
 
                         ArrayPool<StringWithQualityHeaderValue>.Shared.Return(qualityArray);
@@ -102,7 +105,7 @@ namespace System.Web
             }
         }
 
-        public string UserAgent => _request.Headers[HeaderNames.UserAgent];
+        public string? UserAgent => _request.Headers[HeaderNames.UserAgent];
 
         public string RequestType => HttpMethod;
 
@@ -133,7 +136,10 @@ namespace System.Web
 
                         for (var i = 0; i < accept.Count; i++)
                         {
-                            _acceptTypes[i] = accept[i].MediaType.Value;
+                            if (accept[i].MediaType.Value is { } value)
+                            {
+                                _acceptTypes[i] = value;
+                            }
                         }
                     }
                 }
@@ -202,10 +208,14 @@ namespace System.Web
 
         public byte[] BinaryRead(int count)
         {
+#if NET8_0_OR_GREATER
+            ArgumentOutOfRangeException.ThrowIfNegative(count);
+#else
             if (count < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(count));
             }
+#endif
 
             if (count == 0)
             {

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpRequestBase.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpRequestBase.cs
@@ -32,7 +32,7 @@ namespace System.Web
         [Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1819:Properties should not return arrays", Justification = Constants.ApiFromAspNet)]
         public virtual string[] UserLanguages => throw new NotImplementedException();
 
-        public virtual string UserAgent => throw new NotImplementedException();
+        public virtual string? UserAgent => throw new NotImplementedException();
 
         public virtual string RequestType => HttpMethod;
 

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpRequestWrapper.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpRequestWrapper.cs
@@ -73,7 +73,7 @@ namespace System.Web
 
         public override Uri? UrlReferrer => _request.UrlReferrer;
 
-        public override string UserAgent => _request.UserAgent;
+        public override string? UserAgent => _request.UserAgent;
 
         public override string? UserHostAddress => _request.UserHostAddress;
 

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponse.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponse.cs
@@ -166,19 +166,9 @@ namespace System.Web
 
         public void AddHeader(string name, string value) => AppendHeader(name, value);
 
-        public void AppendHeader(string name, string value)
-        {
-            if (_response.Headers.TryGetValue(name, out var existing))
-            {
-                _response.Headers[name] = StringValues.Concat(existing, value);
-            }
-            else
-            {
-                _response.Headers.Add(name, value);
-            }
-        }
+        public void AppendHeader(string name, string value) => _response.Headers.Append(name, value);
 
-        public string RedirectLocation
+        public string? RedirectLocation
         {
             get => _response.Headers.Location;
             set => _response.Headers.Location = value;

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Internal/ServerVariablesNameValueCollection.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Internal/ServerVariablesNameValueCollection.cs
@@ -76,6 +76,9 @@ namespace Microsoft.AspNetCore.SystemWebAdapters.Internal
 
         public override IEnumerator GetEnumerator() => throw new PlatformNotSupportedException(EnumerationErrorMessage);
 
+#if NET8_0_OR_GREATER
+        [Obsolete]
+#endif
         public override void GetObjectData(SerializationInfo info, StreamingContext context) => throw new PlatformNotSupportedException(SerializationErrorMessage);
 
         public override void OnDeserialization(object? sender) => throw new PlatformNotSupportedException(SerializationErrorMessage);

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Microsoft.AspNetCore.SystemWebAdapters.csproj
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Microsoft.AspNetCore.SystemWebAdapters.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.0;net45;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0;netstandard2.0;net45;net472</TargetFrameworks>
     <IsPackable>true</IsPackable>
 
     <!-- This will validate that the package will unify correctly with System.Web.dll -->
@@ -32,7 +32,7 @@
     <Compile Include="HtmlString.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net8.0' ">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
     <PackageReference Include="System.Runtime.Caching" Version="6.0.0" />


### PR DESCRIPTION
This adds a .NET 8 build target to the adapters so we can forward our implementation of IHtmlString to the new in-box version. With this, someone can use IHtmlString in .NET Standard, but will be forwarded on platforms that support it out of the box (i.e. .NET Framework and .NET 8+).

This change also reacts to some nullability changes that occured in .NET 8
