### PR TITLE
Add HttpResponse.BufferOutput

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpResponseAdapterFeature.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpResponseAdapterFeature.cs
@@ -75,6 +75,14 @@ internal class HttpResponseAdapterFeature : Stream, IHttpResponseBodyFeature, IH
         return _responseBodyFeature.StartAsync(cancellationToken);
     }
 
+    bool IHttpResponseBufferingFeature.IsEnabled
+    {
+        get
+        {
+            return _state != StreamState.NotBuffering && _state != StreamState.NotStarted;
+        }
+    }
+
     private async ValueTask FlushInternalAsync()
     {
         if (_state is StreamState.Buffering && _bufferedStream is not null && !SuppressContent)

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/IHttpResponseBufferingFeature.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/IHttpResponseBufferingFeature.cs
@@ -12,6 +12,8 @@ internal interface IHttpResponseBufferingFeature
     void EnableBuffering(int memoryThreshold, long? bufferLimit);
 
     ValueTask FlushAsync();
+
+    bool IsEnabled { get; }
 }
 
 #endif

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Configuration/HttpCapabilitiesBase.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Configuration/HttpCapabilitiesBase.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
-using System.Net;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.SystemWebAdapters;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Configuration/HttpCapabilitiesBase.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Configuration/HttpCapabilitiesBase.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using System.Net;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.SystemWebAdapters;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
@@ -451,6 +451,7 @@ namespace System.Web
     public partial class HttpResponse
     {
         internal HttpResponse() { }
+        public bool BufferOutput { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public System.Web.HttpCachePolicy Cache { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public string Charset { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public System.Text.Encoding ContentEncoding { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
@@ -493,6 +494,7 @@ namespace System.Web
     public partial class HttpResponseBase
     {
         public HttpResponseBase() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        public virtual bool BufferOutput { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual System.Web.HttpCachePolicy Cache { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual string Charset { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual System.Text.Encoding ContentEncoding { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
@@ -528,6 +530,7 @@ namespace System.Web
     public partial class HttpResponseWrapper : System.Web.HttpResponseBase
     {
         public HttpResponseWrapper(System.Web.HttpResponse response) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        public override bool BufferOutput { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override System.Web.HttpCachePolicy Cache { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override string Charset { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override System.Text.Encoding ContentEncoding { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponse.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponse.cs
@@ -175,6 +175,11 @@ namespace System.Web
             get => _response.HasStarted;
         }
 
+        public bool HeadersWritten
+        {
+            get => _response.HasStarted;
+        }
+
         public string? RedirectLocation
         {
             get => _response.Headers.Location;

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponse.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponse.cs
@@ -175,11 +175,6 @@ namespace System.Web
             get => _response.HasStarted;
         }
 
-        public bool HeadersWritten
-        {
-            get => _response.HasStarted;
-        }
-
         public string? RedirectLocation
         {
             get => _response.Headers.Location;

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponse.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponse.cs
@@ -74,6 +74,8 @@ namespace System.Web
             set => _response.HttpContext.Features.GetRequired<IStatusCodePagesFeature>().Enabled = value;
         }
 
+        public bool BufferOutput => _response.HttpContext.Features.GetRequired<IHttpResponseBufferingFeature>().IsEnabled;
+
         public Stream OutputStream => _response.Body;
 
         public HttpCookieCollection Cookies => _cookies ??= new(this);

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponseBase.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponseBase.cs
@@ -63,6 +63,8 @@ namespace System.Web
             set => throw new NotImplementedException();
         }
 
+        public virtual bool BufferOutput  => throw new NotImplementedException();
+
         public virtual Stream OutputStream => throw new NotImplementedException();
 
         public virtual HttpCookieCollection Cookies => throw new NotImplementedException();

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponseWrapper.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponseWrapper.cs
@@ -58,6 +58,8 @@ namespace System.Web
             set => _response.Output = value;
         }
 
+        public override bool BufferOutput => _response.BufferOutput;
+
         public override Stream OutputStream => _response.OutputStream;
 
         public override void SetCookie(HttpCookie cookie) => _response.SetCookie(cookie);

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/ResponseStreamTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/ResponseStreamTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -160,6 +161,28 @@ public class ResponseStreamTests
         }, builder => builder.BufferResponseStream());
 
         Assert.Equal("part4", result);
+    }
+
+    [Fact]
+    public async Task BufferOutputIsNotEnabled()
+    {
+        var result = await RunAsync(context =>
+        {
+            context.Response.Write(context.Response.BufferOutput.ToString());
+        });
+
+        Assert.Equal("False", result);
+    }
+
+    [Fact]
+    public async Task BufferedOutputIsEnabled()
+    {
+        var result = await RunAsync(context =>
+        {
+            context.Response.Write(context.Response.BufferOutput.ToString());
+        }, builder => builder.BufferResponseStream());
+
+        Assert.Equal("True", result);
     }
 
     private static Task<string> RunAsync(Action<HttpContext> action, Action<IEndpointConventionBuilder>? builder = null)


### PR DESCRIPTION
close #374
- add IHttpResponseBufferingFeature.IsEnabled
- implement the property in HttpResponseAdapterFeature
- add Httpresponse.BufferOutput
- add BufferOutput tests in ResponseStreamTests
  - I don't add test for DisableBuffering because I don't find a way to invoke IHttpResponseBodyFeature.DisableBuffering in the test.