### PR TITLE
HttpRuntime.Cache fix in unit tests

### DIFF
--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpRuntimeTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpRuntimeTests.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Web;
+using System.Web.Caching;
+using System.Web.Hosting;
+using AutoFixture;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.AspNetCore.SystemWebAdapters.Tests;
+
+public class HttpRuntimeTests
+{
+    private readonly Fixture _fixture;
+
+    public HttpRuntimeTests()
+    {
+        _fixture = new Fixture();
+
+        // Note: Uncommenting the following lines fixes the issue
+        //
+        //var servicesCollection = new ServiceCollection();
+        //servicesCollection.AddTransient<Cache>();
+
+        //HostingEnvironmentAccessor.Current = new HostingEnvironmentAccessor(
+        //    new DefaultServiceProviderFactory().CreateServiceProvider(servicesCollection),
+        //    Options.Create(new SystemWebAdaptersOptions())
+        //);
+    }
+
+    [Fact]
+    public void SetCache()
+    {
+        // Arrange
+        var cache = HttpRuntime.Cache;
+        var cacheKey = _fixture.Create<string>();
+        var cacheVal = _fixture.Create<string>();
+
+        // Act
+        cache[cacheKey] = cacheVal;
+
+        // Assert
+        Assert.Equal(cacheVal, cache[cacheKey]);
+    }
+}
+


### PR DESCRIPTION


- [X] You've read the [Contributor Guide](../CONTRIBUTING.md) and [Code of Conduct](../CODE-OF-CONDUCT.md).
- [X] You've included unit tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**PR Title**

PR to fix the `HttpRuntime.Cache` runtime exception in unit tests

**PR Description**

This is not a fix, I added this test to show how it can be reproduced and also propose a potential fix.


Addresses #401
