### PR TITLE
Move HttpApplication middleware into UseSystemWebAdapters

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpApplication/HttpApplicationExtensions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpApplication/HttpApplicationExtensions.cs
@@ -52,7 +52,6 @@ public static class HttpApplicationExtensions
         });
 
         return builder;
-
     }
 
     public static ISystemWebAdapterBuilder AddHttpApplication<TApp>(this ISystemWebAdapterBuilder builder, Action<HttpApplicationOptions> configure)

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpApplication/HttpApplicationExtensions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpApplication/HttpApplicationExtensions.cs
@@ -42,6 +42,19 @@ public static class HttpApplicationExtensions
         return builder;
     }
 
+    public static ISystemWebAdapterBuilder AddHttpApplication<TApp>(this ISystemWebAdapterBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.AddHttpApplication(options =>
+        {
+            options.ApplicationType = typeof(TApp);
+        });
+
+        return builder;
+
+    }
+
     public static ISystemWebAdapterBuilder AddHttpApplication<TApp>(this ISystemWebAdapterBuilder builder, Action<HttpApplicationOptions> configure)
         where TApp : HttpApplication
     {

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/SystemWebAdaptersExtensions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/SystemWebAdaptersExtensions.cs
@@ -60,11 +60,21 @@ public static class SystemWebAdaptersExtensions
             return;
         }
 
+        if (app.AreHttpApplicationEventsRequired())
+        {
+            app.UseMiddleware<HttpApplicationMiddleware>();
+        }
+
         app.UseMiddleware<PreBufferRequestStreamMiddleware>();
         app.UseMiddleware<BufferResponseStreamMiddleware>();
         app.UseMiddleware<SetDefaultResponseHeadersMiddleware>();
         app.UseMiddleware<SingleThreadedRequestMiddleware>();
         app.UseMiddleware<CurrentPrincipalMiddleware>();
+
+        if (app.AreHttpApplicationEventsRequired())
+        {
+            app.UseHttpApplicationEvent(ApplicationEvent.BeginRequest);
+        }
     }
 
     public static void UseSystemWebAdapters(this IApplicationBuilder app)
@@ -133,12 +143,6 @@ public static class SystemWebAdaptersExtensions
             {
                 builder.UseMiddleware<SetHttpContextTimestampMiddleware>();
                 builder.UseMiddleware<RegisterAdapterFeaturesMiddleware>();
-
-                if (builder.AreHttpApplicationEventsRequired())
-                {
-                    builder.UseMiddleware<HttpApplicationMiddleware>();
-                    builder.UseHttpApplicationEvent(ApplicationEvent.BeginRequest);
-                }
 
                 next(builder);
             };

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/SystemWebAdaptersExtensions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/SystemWebAdaptersExtensions.cs
@@ -60,6 +60,8 @@ public static class SystemWebAdaptersExtensions
             return;
         }
 
+        app.UseMiddleware<RegisterAdapterFeaturesMiddleware>();
+
         if (app.AreHttpApplicationEventsRequired())
         {
             app.UseMiddleware<HttpApplicationMiddleware>();
@@ -142,7 +144,6 @@ public static class SystemWebAdaptersExtensions
             => builder =>
             {
                 builder.UseMiddleware<SetHttpContextTimestampMiddleware>();
-                builder.UseMiddleware<RegisterAdapterFeaturesMiddleware>();
 
                 next(builder);
             };

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests.csproj
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac.Extras.Moq" Version="6.0.0" />

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/OutputCachingTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/OutputCachingTests.cs
@@ -40,7 +40,7 @@ public class OutputCachingTests
                       services.AddRouting();
                       services.AddSystemWebAdapters()
                         .AddHttpApplication<MyApp>();
-                      services.AddOutputCache()
+                      services.AddOutputCache();
                   })
                   .Configure(app =>
                   {

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/OutputCachingTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/OutputCachingTests.cs
@@ -1,0 +1,110 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if NET7_0_OR_GREATER
+
+using System;
+using System.Configuration;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Web;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.OutputCaching;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests;
+
+[Collection(nameof(SelfHostedTests))]
+public class OutputCachingTests
+{
+    [Fact]
+    public async Task OutputCachingWorksWithHttpApplication()
+    {
+        // Arrange
+        using var host = await new HostBuilder()
+          .ConfigureWebHost(webBuilder =>
+          {
+              webBuilder
+                  .UseTestServer(options =>
+                  {
+                      options.AllowSynchronousIO = true;
+                  })
+                  .ConfigureServices(services =>
+                  {
+                      services.AddRouting();
+                      services.AddSystemWebAdapters()
+                        .AddHttpApplication<MyApp>();
+                      services.AddOutputCache(options =>
+                      {
+                          //options.AddHttpApplicationBasePolicy(_ => new[] { MyApp.VaryBy });
+                      });
+                  })
+                  .Configure(app =>
+                  {
+                      app.UseRouting();
+                      app.UseSystemWebAdapters();
+                      app.UseOutputCache();
+                      app.UseEndpoints(endpoints =>
+                      {
+                          var count = 0;
+                          endpoints.Map("/", () => Results.Ok(count++))
+                          .CacheOutput(builder =>
+                          {
+                              builder.AddHttpApplicationVaryByCustom(MyApp.VaryBy);
+                          });
+                      });
+                  });
+          })
+          .StartAsync();
+
+        using var client = host.GetTestClient();
+
+        // Act
+        var result1 = await GetResponseAsync(client, "test");
+        var result2 = await GetResponseAsync(client, "other");
+        var result3 = await GetResponseAsync(client, "test");
+
+        // Assert
+        Assert.Equal("0", result1);
+        Assert.Equal("1", result2);
+        Assert.Equal("0", result3);
+
+        static async Task<string> GetResponseAsync(HttpClient client, string value)
+        {
+            using var message = new HttpRequestMessage(HttpMethod.Get, new Uri("/", UriKind.Relative))
+            {
+                Headers =
+                {
+                    { MyApp.Header, value }
+                }
+            };
+
+            using var response = await client.SendAsync(message);
+
+            return await response.Content.ReadAsStringAsync();
+        }
+    }
+
+    private sealed class MyApp : HttpApplication
+    {
+        public const string VaryBy = "myValue";
+        public const string Header = "X-TEST-HEADER";
+
+        public override string? GetVaryByCustomString(HttpContext context, string custom)
+        {
+            if (custom == VaryBy)
+            {
+                return context.Request.Headers[Header];
+            }
+
+            return base.GetVaryByCustomString(context, custom);
+        }
+    }
+}
+#endif

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/OutputCachingTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/OutputCachingTests.cs
@@ -40,10 +40,7 @@ public class OutputCachingTests
                       services.AddRouting();
                       services.AddSystemWebAdapters()
                         .AddHttpApplication<MyApp>();
-                      services.AddOutputCache(options =>
-                      {
-                          //options.AddHttpApplicationBasePolicy(_ => new[] { MyApp.VaryBy });
-                      });
+                      services.AddOutputCache()
                   })
                   .Configure(app =>
                   {


### PR DESCRIPTION
This was initially moved into the startup filter to be added early on in the request pipeline because it was thought it was needed there for output caching. However, that does not seem to be the case (test has been added for that). So, now it can be moved into the standard `UseSystemWebAdapters()` so that it will be only added on requests that needed it (i.e. if the pipeline has been branched and `UseSystemWebAdapters()` is not added).

Fixes #405
