### PR TITLE
Use TimeProvider to set HttpContext.Timestamp

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Authentication/RemoteAppAuthenticationAuthHandler.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Authentication/RemoteAppAuthenticationAuthHandler.cs
@@ -29,9 +29,13 @@ internal partial class RemoteAppAuthenticationAuthHandler : AuthenticationHandle
                                            IEnumerable<IRemoteAppAuthenticationResultProcessor> resultProcessors,
                                            IOptionsMonitor<RemoteAppAuthenticationClientOptions> options,
                                            ILoggerFactory loggerFactory,
-                                           UrlEncoder encoder,
-                                           ISystemClock clock)
+                                           UrlEncoder encoder
+#if NET8_0_OR_GREATER
+        ) : base(options, loggerFactory, encoder)
+#else
+        , ISystemClock clock)
         : base(options, loggerFactory, encoder, clock)
+#endif
     {
         _logger = loggerFactory.CreateLogger<RemoteAppAuthenticationAuthHandler>();
         _authService = authService;

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Authentication/RemoteAppAuthenticationResultFactory.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Authentication/RemoteAppAuthenticationResultFactory.cs
@@ -8,6 +8,7 @@ using System.Net;
 using System.Net.Http;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.SystemWebAdapters.Authentication;
 
@@ -44,7 +45,7 @@ internal class RemoteAppAuthenticationResultFactory : IAuthenticationResultFacto
         {
             if (forwardAllResponseHeaders || options.ResponseHeadersToForward.Contains(responseHeader.Key))
             {
-                ret.ResponseHeaders.Add(responseHeader.Key, responseHeader.Value.ToArray());
+                ret.ResponseHeaders.AppendList(responseHeader.Key, responseHeader.Value.ToList());
             }
         }
 

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Authentication/ResultProcessors/RedirectUrlProcessor.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Authentication/ResultProcessors/RedirectUrlProcessor.cs
@@ -43,7 +43,7 @@ internal class RedirectUrlProcessor : IRemoteAppAuthenticationResultProcessor
                 }
             }
             result.ResponseHeaders.Remove(LocationHeaderName);
-            result.ResponseHeaders.Add(LocationHeaderName, processedRedirectLocations.ToArray());
+            result.ResponseHeaders.AppendList(LocationHeaderName, processedRedirectLocations);
         }
 
         return Task.CompletedTask;

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.csproj
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.csproj
@@ -16,6 +16,9 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' ">
+    <PackageReference Include="Microsoft.Bcl.TimeProvider" Version="8.0.0-rtm.23503.5" />
+  </ItemGroup>
   <ItemGroup>
     <Using Include="Microsoft.AspNetCore.Http.HttpContext" Alias="HttpContextCore" />
     <Using Include="Microsoft.AspNetCore.Http.HttpResponse" Alias="HttpResponseCore" />

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.csproj
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <EnablePackageValidation>true</EnablePackageValidation>
     <RootNamespace>Microsoft.AspNetCore.SystemWebAdapters</RootNamespace>

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.csproj
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.csproj
@@ -17,7 +17,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' ">
-    <PackageReference Include="Microsoft.Bcl.TimeProvider" Version="8.0.0-rtm.23503.5" />
+    <PackageReference Include="Microsoft.Bcl.TimeProvider" Version="8.0.0-rc.1.23419.4" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Microsoft.AspNetCore.Http.HttpContext" Alias="HttpContextCore" />

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/SessionState/RemoteSession/RemoteAppSessionStateManager.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/SessionState/RemoteSession/RemoteAppSessionStateManager.cs
@@ -8,6 +8,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.SystemWebAdapters.SessionState.Serialization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -130,7 +131,7 @@ internal partial class RemoteAppSessionStateManager : ISessionManager
     {
         if (context?.Response is not null && responseMessage.Headers.TryGetValues(cookieName, out var cookieValues))
         {
-            context.Response.Headers.Add(cookieName, cookieValues.ToArray());
+            context.Response.Headers.AppendList(cookieName, cookieValues.ToArray());
         }
     }
 

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/SystemWebAdaptersExtensions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/SystemWebAdaptersExtensions.cs
@@ -8,6 +8,7 @@ using System.Web.Configuration;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.SystemWebAdapters;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Extensions.DependencyInjection;
@@ -17,6 +18,7 @@ public static class SystemWebAdaptersExtensions
     public static ISystemWebAdapterBuilder AddSystemWebAdapters(this IServiceCollection services)
     {
         services.AddHttpContextAccessor();
+        services.TryAddSingleton(TimeProvider.System);
         services.AddSingleton<Cache>();
         services.AddSingleton<IBrowserCapabilitiesFactory, BrowserCapabilitiesFactory>();
         services.AddTransient<IStartupFilter, HttpContextStartupFilter>();

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/ITimestampFeature.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/ITimestampFeature.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if NET6_0_OR_GREATER
+using System;
+
+namespace Microsoft.AspNetCore.SystemWebAdapters;
+
+internal interface ITimestampFeature
+{
+    DateTimeOffset Timestamp { get; }
+}
+#endif

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
@@ -147,7 +147,7 @@ namespace System.Web
         public System.Web.HttpResponse Response { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public System.Web.HttpServerUtility Server { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public System.Web.SessionState.HttpSessionState Session { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
-        public System.DateTime Timestamp { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public System.DateTime Timestamp { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public System.Web.TraceContext Trace { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public System.Security.Principal.IPrincipal User { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public void AddError(System.Exception ex) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpContext.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpContext.cs
@@ -90,7 +90,7 @@ public class HttpContext : IServiceProvider
 
     public HttpSessionState? Session => _context.Features.Get<HttpSessionState>();
 
-    public DateTime Timestamp { get; } = DateTime.UtcNow.ToLocalTime();
+    public DateTime Timestamp => _context.Features.GetRequired<ITimestampFeature>().Timestamp.DateTime;
 
     public void RewritePath(string path) => RewritePath(path, true);
 

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests.csproj
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac.Extras.Moq" Version="6.0.0" />


### PR DESCRIPTION
In order to use this, we need to move the timestamp to a feature so we can set this in the middleware where we have TimeProvider. As a benefit of this, we won't prematurely create a `System.Web.HttpContext` to initialize the time; instead, the feature will be created, but that's it.

Another change this requires is to add a .NET 8 build for the CoreServices library, which raises a few new warnings about some API changes that are addressed in this PR as well.
