### PR TITLE
Add HttpServerUtility.Transfer/Execute methods

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/ITransferRequestFeature.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/ITransferRequestFeature.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if NETCOREAPP
+
+using System.Collections.Specialized;
+using System.IO;
+
+namespace Microsoft.AspNetCore.SystemWebAdapters;
+
+internal interface ITransferRequestFeature
+{
+    void Transfer(string path, bool preserveForm) => Execute(path, null, preserveForm);
+
+    void Execute(string path, TextWriter? writer, bool preserveForm);
+
+    void TransferRequest(string path, bool preserveForm, string? method, NameValueCollection? headers, bool preserveUser);
+}
+
+#endif

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Constants.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Constants.cs
@@ -12,4 +12,22 @@ internal static class Constants
     internal const string DisposeIsRegistered = "Object is registered for dispose with HttpContext";
 
     internal const string CA1859 = "False positive fixed by https://github.com/dotnet/roslyn-analyzers/pull/6421 but not integrated in yet";
+
+    internal static class TransferRequest
+    {
+        public const string Message = "TransferRequest is not supported on ASP.NET Core";
+        public const string DiagnosticId = "SYSWEB0001";
+    }
+
+    internal static class Execute
+    {
+        public const string Message = "Execute is not supported on ASP.NET Core";
+        public const string DiagnosticId = "SYSWEB0002";
+    }
+
+    internal static class Transfer
+    {
+        public const string Message = "Transfer is not supported on ASP.NET Core";
+        public const string DiagnosticId = "SYSWEB0003";
+    }
 }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Header.txt
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Header.txt
@@ -17,4 +17,5 @@
 #pragma warning disable CS0809 // Obsolete member overrides non-obsolete member
 #pragma warning disable CA1063 // Implement IDisposable Correctly
 #pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
+#pragma warning disable CS0436 // Type conflicts with imported type
 

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Obsolete.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Obsolete.cs
@@ -21,12 +21,6 @@ internal sealed class ObsoleteAttribute : Attribute
         Message = message;
     }
 
-    public ObsoleteAttribute(string? message, bool error)
-    {
-        Message = message;
-        IsError = error;
-    }
-
     public string? Message { get; }
 
     public bool IsError { get; }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Obsolete.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Obsolete.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if NETSTANDARD
+namespace System;
+
+/// <summary>
+/// An internal implementation to enable <see cref="DiagnosticId"/> on .NET Standard.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum |
+    AttributeTargets.Interface | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Event | AttributeTargets.Delegate,
+    Inherited = false)]
+internal sealed class ObsoleteAttribute : Attribute
+{
+    public ObsoleteAttribute()
+    {
+    }
+
+    public ObsoleteAttribute(string? message)
+    {
+        Message = message;
+    }
+
+    public ObsoleteAttribute(string? message, bool error)
+    {
+        Message = message;
+        IsError = error;
+    }
+
+    public string? Message { get; }
+
+    public bool IsError { get; }
+
+    public string? DiagnosticId { get; set; }
+
+    public string? UrlFormat { get; set; }
+}
+#endif

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
@@ -579,26 +579,36 @@ namespace System.Web
         internal HttpServerUtility() { }
         public string MachineName { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public void ClearError() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         [System.ObsoleteAttribute("Execute is not supported on ASP.NET Core", DiagnosticId="SYSWEB0002")]
         public void Execute(string path) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         [System.ObsoleteAttribute("Execute is not supported on ASP.NET Core", DiagnosticId="SYSWEB0002")]
         public void Execute(string path, bool preserveForm) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         [System.ObsoleteAttribute("Execute is not supported on ASP.NET Core", DiagnosticId="SYSWEB0002")]
         public void Execute(string path, System.IO.TextWriter writer) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         [System.ObsoleteAttribute("Execute is not supported on ASP.NET Core", DiagnosticId="SYSWEB0002")]
         public void Execute(string path, System.IO.TextWriter writer, bool preserveForm) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public System.Exception GetLastError() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public string MapPath(string path) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         [System.ObsoleteAttribute("Transfer is not supported on ASP.NET Core", DiagnosticId="SYSWEB0003")]
         public void Transfer(string path) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         [System.ObsoleteAttribute("Transfer is not supported on ASP.NET Core", DiagnosticId="SYSWEB0003")]
         public void Transfer(string path, bool preserveForm) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         [System.ObsoleteAttribute("TransferRequest is not supported on ASP.NET Core", DiagnosticId="SYSWEB0001")]
         public void TransferRequest(string path) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         [System.ObsoleteAttribute("TransferRequest is not supported on ASP.NET Core", DiagnosticId="SYSWEB0001")]
         public void TransferRequest(string path, bool preserveForm) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         [System.ObsoleteAttribute("TransferRequest is not supported on ASP.NET Core", DiagnosticId="SYSWEB0001")]
         public void TransferRequest(string path, bool preserveForm, string method, System.Collections.Specialized.NameValueCollection headers) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         [System.ObsoleteAttribute("TransferRequest is not supported on ASP.NET Core", DiagnosticId="SYSWEB0001")]
         public void TransferRequest(string path, bool preserveForm, string method, System.Collections.Specialized.NameValueCollection headers, bool preserveUser) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public static byte[] UrlTokenDecode(string input) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
@@ -17,6 +17,7 @@
 #pragma warning disable CS0809 // Obsolete member overrides non-obsolete member
 #pragma warning disable CA1063 // Implement IDisposable Correctly
 #pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
+#pragma warning disable CS0436 // Type conflicts with imported type
 
 namespace System.Web
 {
@@ -578,8 +579,28 @@ namespace System.Web
         internal HttpServerUtility() { }
         public string MachineName { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public void ClearError() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        [System.ObsoleteAttribute("Execute is not supported on ASP.NET Core", DiagnosticId="SYSWEB0002")]
+        public void Execute(string path) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        [System.ObsoleteAttribute("Execute is not supported on ASP.NET Core", DiagnosticId="SYSWEB0002")]
+        public void Execute(string path, bool preserveForm) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        [System.ObsoleteAttribute("Execute is not supported on ASP.NET Core", DiagnosticId="SYSWEB0002")]
+        public void Execute(string path, System.IO.TextWriter writer) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        [System.ObsoleteAttribute("Execute is not supported on ASP.NET Core", DiagnosticId="SYSWEB0002")]
+        public void Execute(string path, System.IO.TextWriter writer, bool preserveForm) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public System.Exception GetLastError() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public string MapPath(string path) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        [System.ObsoleteAttribute("Transfer is not supported on ASP.NET Core", DiagnosticId="SYSWEB0003")]
+        public void Transfer(string path) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        [System.ObsoleteAttribute("Transfer is not supported on ASP.NET Core", DiagnosticId="SYSWEB0003")]
+        public void Transfer(string path, bool preserveForm) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        [System.ObsoleteAttribute("TransferRequest is not supported on ASP.NET Core", DiagnosticId="SYSWEB0001")]
+        public void TransferRequest(string path) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        [System.ObsoleteAttribute("TransferRequest is not supported on ASP.NET Core", DiagnosticId="SYSWEB0001")]
+        public void TransferRequest(string path, bool preserveForm) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        [System.ObsoleteAttribute("TransferRequest is not supported on ASP.NET Core", DiagnosticId="SYSWEB0001")]
+        public void TransferRequest(string path, bool preserveForm, string method, System.Collections.Specialized.NameValueCollection headers) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        [System.ObsoleteAttribute("TransferRequest is not supported on ASP.NET Core", DiagnosticId="SYSWEB0001")]
+        public void TransferRequest(string path, bool preserveForm, string method, System.Collections.Specialized.NameValueCollection headers, bool preserveUser) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public static byte[] UrlTokenDecode(string input) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public static string UrlTokenEncode(byte[] input) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
     }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/TypeForwards.Framework.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/TypeForwards.Framework.cs
@@ -17,6 +17,7 @@
 #pragma warning disable CS0809 // Obsolete member overrides non-obsolete member
 #pragma warning disable CA1063 // Implement IDisposable Correctly
 #pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
+#pragma warning disable CS0436 // Type conflicts with imported type
 
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.HttpApplication))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.HttpApplicationState))]

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpServerUtility.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpServerUtility.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Specialized;
+using System.ComponentModel;
 using System.IO;
 using System.Web.Hosting;
 using Microsoft.AspNetCore.SystemWebAdapters;
@@ -87,32 +88,42 @@ public class HttpServerUtility
     }
 
     [Obsolete(Constants.Execute.Message, DiagnosticId = Constants.Execute.DiagnosticId)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public void Execute(string path) => throw new PlatformNotSupportedException();
 
     [Obsolete(Constants.Execute.Message, DiagnosticId = Constants.Execute.DiagnosticId)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public void Execute(string path, TextWriter writer) => throw new PlatformNotSupportedException();
 
     [Obsolete(Constants.Execute.Message, DiagnosticId = Constants.Execute.DiagnosticId)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public void Execute(string path, bool preserveForm) => throw new PlatformNotSupportedException();
 
     [Obsolete(Constants.Execute.Message, DiagnosticId = Constants.Execute.DiagnosticId)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public void Execute(string path, TextWriter writer, bool preserveForm) => throw new PlatformNotSupportedException();
 
     [Obsolete(Constants.Transfer.Message, DiagnosticId = Constants.Transfer.DiagnosticId)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public void Transfer(string path) => throw new PlatformNotSupportedException();
 
     [Obsolete(Constants.Transfer.Message, DiagnosticId = Constants.Transfer.DiagnosticId)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public void Transfer(string path, bool preserveForm) => throw new PlatformNotSupportedException();
 
     [Obsolete(Constants.TransferRequest.Message, DiagnosticId = Constants.TransferRequest.DiagnosticId)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public void TransferRequest(string path) => throw new PlatformNotSupportedException();
 
     [Obsolete(Constants.TransferRequest.Message, DiagnosticId = Constants.TransferRequest.DiagnosticId)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public void TransferRequest(string path, bool preserveForm) => throw new PlatformNotSupportedException();
 
     [Obsolete(Constants.TransferRequest.Message, DiagnosticId = Constants.TransferRequest.DiagnosticId)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public void TransferRequest(string path, bool preserveForm, string method, NameValueCollection headers) => throw new PlatformNotSupportedException();
 
     [Obsolete(Constants.TransferRequest.Message, DiagnosticId = Constants.TransferRequest.DiagnosticId)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public void TransferRequest(string path, bool preserveForm, string method, NameValueCollection headers, bool preserveUser) => throw new PlatformNotSupportedException();
 }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpServerUtility.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpServerUtility.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Specialized;
+using System.IO;
 using System.Web.Hosting;
 using Microsoft.AspNetCore.SystemWebAdapters;
 using Microsoft.AspNetCore.WebUtilities;
@@ -83,4 +85,34 @@ public class HttpServerUtility
 
         return $"{encoded}{padding}";
     }
+
+    [Obsolete(Constants.Execute.Message, DiagnosticId = Constants.Execute.DiagnosticId)]
+    public void Execute(string path) => throw new PlatformNotSupportedException();
+
+    [Obsolete(Constants.Execute.Message, DiagnosticId = Constants.Execute.DiagnosticId)]
+    public void Execute(string path, TextWriter writer) => throw new PlatformNotSupportedException();
+
+    [Obsolete(Constants.Execute.Message, DiagnosticId = Constants.Execute.DiagnosticId)]
+    public void Execute(string path, bool preserveForm) => throw new PlatformNotSupportedException();
+
+    [Obsolete(Constants.Execute.Message, DiagnosticId = Constants.Execute.DiagnosticId)]
+    public void Execute(string path, TextWriter writer, bool preserveForm) => throw new PlatformNotSupportedException();
+
+    [Obsolete(Constants.Transfer.Message, DiagnosticId = Constants.Transfer.DiagnosticId)]
+    public void Transfer(string path) => throw new PlatformNotSupportedException();
+
+    [Obsolete(Constants.Transfer.Message, DiagnosticId = Constants.Transfer.DiagnosticId)]
+    public void Transfer(string path, bool preserveForm) => throw new PlatformNotSupportedException();
+
+    [Obsolete(Constants.TransferRequest.Message, DiagnosticId = Constants.TransferRequest.DiagnosticId)]
+    public void TransferRequest(string path) => throw new PlatformNotSupportedException();
+
+    [Obsolete(Constants.TransferRequest.Message, DiagnosticId = Constants.TransferRequest.DiagnosticId)]
+    public void TransferRequest(string path, bool preserveForm) => throw new PlatformNotSupportedException();
+
+    [Obsolete(Constants.TransferRequest.Message, DiagnosticId = Constants.TransferRequest.DiagnosticId)]
+    public void TransferRequest(string path, bool preserveForm, string method, NameValueCollection headers) => throw new PlatformNotSupportedException();
+
+    [Obsolete(Constants.TransferRequest.Message, DiagnosticId = Constants.TransferRequest.DiagnosticId)]
+    public void TransferRequest(string path, bool preserveForm, string method, NameValueCollection headers, bool preserveUser) => throw new PlatformNotSupportedException();
 }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpServerUtility.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpServerUtility.cs
@@ -89,41 +89,49 @@ public class HttpServerUtility
 
     [Obsolete(Constants.Execute.Message, DiagnosticId = Constants.Execute.DiagnosticId)]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public void Execute(string path) => throw new PlatformNotSupportedException();
+    public void Execute(string path) => Execute(path, null, preserveForm: true);
 
     [Obsolete(Constants.Execute.Message, DiagnosticId = Constants.Execute.DiagnosticId)]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public void Execute(string path, TextWriter writer) => throw new PlatformNotSupportedException();
+    public void Execute(string path, TextWriter writer) => Execute(path, writer, preserveForm: true);
 
     [Obsolete(Constants.Execute.Message, DiagnosticId = Constants.Execute.DiagnosticId)]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public void Execute(string path, bool preserveForm) => throw new PlatformNotSupportedException();
+    public void Execute(string path, bool preserveForm) => Execute(path, null, preserveForm);
 
     [Obsolete(Constants.Execute.Message, DiagnosticId = Constants.Execute.DiagnosticId)]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public void Execute(string path, TextWriter writer, bool preserveForm) => throw new PlatformNotSupportedException();
+    public void Execute(string path, TextWriter? writer, bool preserveForm) => _context.Features.GetRequired<ITransferRequestFeature>().Execute(path, writer, preserveForm);
 
     [Obsolete(Constants.Transfer.Message, DiagnosticId = Constants.Transfer.DiagnosticId)]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public void Transfer(string path) => throw new PlatformNotSupportedException();
+    public void Transfer(string path) => Transfer(path, preserveForm: true);
 
     [Obsolete(Constants.Transfer.Message, DiagnosticId = Constants.Transfer.DiagnosticId)]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public void Transfer(string path, bool preserveForm) => throw new PlatformNotSupportedException();
+    public void Transfer(string path, bool preserveForm)
+    {
+        _context.Features.GetRequired<ITransferRequestFeature>().Transfer(path, preserveForm);
+        _context.Response.GetAdapter().End();
+    }
 
     [Obsolete(Constants.TransferRequest.Message, DiagnosticId = Constants.TransferRequest.DiagnosticId)]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public void TransferRequest(string path) => throw new PlatformNotSupportedException();
+    public void TransferRequest(string path)
+        => TransferRequest(path, false, null, null, preserveUser: true);
 
     [Obsolete(Constants.TransferRequest.Message, DiagnosticId = Constants.TransferRequest.DiagnosticId)]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public void TransferRequest(string path, bool preserveForm) => throw new PlatformNotSupportedException();
+    public void TransferRequest(string path, bool preserveForm)
+        => TransferRequest(path, preserveForm, null, null, preserveUser: true);
 
     [Obsolete(Constants.TransferRequest.Message, DiagnosticId = Constants.TransferRequest.DiagnosticId)]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public void TransferRequest(string path, bool preserveForm, string method, NameValueCollection headers) => throw new PlatformNotSupportedException();
+    public void TransferRequest(string path, bool preserveForm, string? method, NameValueCollection? headers)
+        => TransferRequest(path, preserveForm, method, headers, preserveUser: true);
 
     [Obsolete(Constants.TransferRequest.Message, DiagnosticId = Constants.TransferRequest.DiagnosticId)]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public void TransferRequest(string path, bool preserveForm, string method, NameValueCollection headers, bool preserveUser) => throw new PlatformNotSupportedException();
+    public void TransferRequest(string path, bool preserveForm, string? method, NameValueCollection? headers, bool preserveUser)
+        => _context.Features.GetRequired<ITransferRequestFeature>().TransferRequest(path, preserveForm, method, headers, preserveUser);
 }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Microsoft.AspNetCore.SystemWebAdapters.csproj
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Microsoft.AspNetCore.SystemWebAdapters.csproj
@@ -30,6 +30,7 @@
     <Compile Remove="**/*" />
     <Compile Include="Properties/PropertyInfo.cs" />
     <Compile Include="Generated/Ref.*.cs" />
+    <Compile Include="Generated\Obsolete.cs" />
     <Compile Include="Adapters/SessionState/ISessionState.cs" />
     <Compile Include="IHtmlString.cs" />
     <Compile Include="HtmlString.cs" />


### PR DESCRIPTION
This should help with some migrations that use the type to highlight they need to refactor. For now, there's no implementation and it will throw if used, as well as show warnings when compiling. However, if there's a way to implement it (and if there's enough demand) an internal interface is available that that can be implemented to light up the feature.

Fixes #377
