### PR TITLE
Enable HttpRequest.PhysicalPath

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpRequestInputStreamFeature.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpRequestInputStreamFeature.cs
@@ -217,6 +217,8 @@ internal class HttpRequestInputStreamFeature : IHttpRequestInputStreamFeature, I
 
     string IHttpRequestPathFeature.CurrentExecutionFilePath => _filePath ?? Path;
 
+    string? IHttpRequestPathFeature.PhysicalPath => null;
+
     internal static class AspNetCoreTempDirectory
     {
         private static string? _tempDirectory;

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/IHttpRequestPathFeature.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/IHttpRequestPathFeature.cs
@@ -13,6 +13,8 @@ internal interface IHttpRequestPathFeature
 
     string RawUrl { get; }
 
+    string? PhysicalPath { get; }
+
     string CurrentExecutionFilePath { get; }
 
     void Rewrite(string filePath, string pathInfo, string? queryString, bool setClientFilePath);

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
@@ -352,6 +352,7 @@ namespace System.Web
         public System.Collections.Specialized.NameValueCollection Params { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public string Path { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public string PathInfo { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public string PhysicalPath { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public System.Collections.Specialized.NameValueCollection QueryString { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public string RawUrl { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public System.Web.ReadEntityBodyMode ReadEntityBodyMode { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
@@ -394,6 +394,7 @@ namespace System.Web
         public virtual System.Security.Principal.IIdentity LogonUserIdentity { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual System.Collections.Specialized.NameValueCollection Params { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual string Path { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public virtual string PhysicalPath { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual System.Collections.Specialized.NameValueCollection QueryString { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual string RawUrl { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual string RequestType { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
@@ -433,6 +434,7 @@ namespace System.Web
         public override System.Security.Principal.IIdentity LogonUserIdentity { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override System.Collections.Specialized.NameValueCollection Params { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override string Path { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public override string PhysicalPath { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override System.Collections.Specialized.NameValueCollection QueryString { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override string RawUrl { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override string RequestType { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpRequest.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpRequest.cs
@@ -52,6 +52,8 @@ namespace System.Web
         [SuppressMessage("Design", "CA1056:URI-like properties should not be strings", Justification = Constants.ApiFromAspNet)]
         public string RawUrl => _request.HttpContext.Features.GetRequired<IHttpRequestPathFeature>().RawUrl;
 
+        public string? PhysicalPath => _request.HttpContext.Features.GetRequired<IHttpRequestPathFeature>().PhysicalPath;
+
         public string CurrentExecutionFilePath => _request.HttpContext.Features.GetRequired<IHttpRequestPathFeature>().CurrentExecutionFilePath;
 
         public NameValueCollection Headers => _headers ??= _request.Headers.ToNameValueCollection();

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpRequestBase.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpRequestBase.cs
@@ -18,6 +18,8 @@ namespace System.Web
 
         public virtual string Path => throw new NotImplementedException();
 
+        public virtual string? PhysicalPath => throw new NotImplementedException();
+
         public virtual NameValueCollection Headers => throw new NotImplementedException();
 
         public virtual Uri Url => throw new NotImplementedException();

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpRequestWrapper.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpRequestWrapper.cs
@@ -59,6 +59,8 @@ namespace System.Web
 
         public override string Path => _request.Path;
 
+        public override string? PhysicalPath => _request.PhysicalPath;
+
         public override NameValueCollection QueryString => _request.QueryString;
 
         public override HttpBrowserCapabilitiesBase Browser => new HttpBrowserCapabilitiesWrapper(_request.Browser);


### PR DESCRIPTION
This change just adds the API with a default to null as we don't really have an equivalent for what a physical path is in ASP.NET Core.

Fixes #373
