### PR TITLE
Add a setter for HttpContext.Current

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
@@ -138,7 +138,7 @@ namespace System.Web
         public System.Web.HttpApplicationState Application { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public System.Web.HttpApplication ApplicationInstance { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public System.Web.Caching.Cache Cache { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
-        public static System.Web.HttpContext Current { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public static System.Web.HttpContext Current { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public System.Web.RequestNotification CurrentNotification { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public System.Exception Error { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public bool IsDebuggingEnabled { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpContext.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpContext.cs
@@ -28,7 +28,11 @@ public class HttpContext : IServiceProvider
     private IDictionary? _items;
     private TraceContext? _trace;
 
-    public static HttpContext? Current => _accessor.HttpContext;
+    public static HttpContext? Current
+    {
+        get => _accessor.HttpContext;
+        set => _accessor.HttpContext = value;
+    }
 
     internal HttpContext(HttpContextCore context)
     {

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpContextTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpContextTests.cs
@@ -471,5 +471,35 @@ namespace Microsoft.AspNetCore.SystemWebAdapters
             // Assert
             feature.Verify(f => f.Rewrite(filePath, pathInfo, query, rebase), Times.Once);
         }
+
+        [Fact]
+        public void SetHttpContext()
+        {
+            // Arrange
+            var coreContext = new DefaultHttpContext();
+            var context = new HttpContext(coreContext);
+
+            // Act
+            HttpContext.Current = context;
+
+            // Assert
+            Assert.IsType<HttpContext>(HttpContext.Current);
+        }
+
+
+        [Fact]
+        public void SetHttpContextToNull()
+        {
+            // Arrange
+            var coreContext = new DefaultHttpContext();
+            var context = new HttpContext(coreContext);
+            HttpContext.Current = context;
+
+            // Act
+            HttpContext.Current = null;
+
+            // Assert
+            Assert.Null(HttpContext.Current);
+        }
     }
 }

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpContextTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpContextTests.cs
@@ -486,7 +486,6 @@ namespace Microsoft.AspNetCore.SystemWebAdapters
             Assert.IsType<HttpContext>(HttpContext.Current);
         }
 
-
         [Fact]
         public void SetHttpContextToNull()
         {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the systemweb-adapters repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](../CONTRIBUTING.md) and [Code of Conduct](../CODE-OF-CONDUCT.md).
- [X] You've included unit tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**PR Title**
Add a setter for `HttpContext.Current`

**PR Description**

Looking at the `System.Web` implementation, it seems like `HttpContext.Current` is not read-only https://github.com/microsoft/referencesource/blob/master/System.Web/HttpContext.cs#L566-L579 which is different than our implementation https://github.com/dotnet/systemweb-adapters/blob/main/src/Microsoft.AspNetCore.SystemWebAdapters/HttpContext.cs#L31

Addresses #400
