### PR TITLE
Separate HttpApplication feature insertion from invocation

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpApplication/HttpApplicationMiddleware.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpApplication/HttpApplicationMiddleware.cs
@@ -2,57 +2,28 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading.Tasks;
-using System.Web;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.SystemWebAdapters.Features;
-using Microsoft.Extensions.ObjectPool;
 
 namespace Microsoft.AspNetCore.SystemWebAdapters;
 
 internal class HttpApplicationMiddleware
 {
     private readonly RequestDelegate _next;
-    private readonly ObjectPool<HttpApplication> _pool;
 
-    public HttpApplicationMiddleware(RequestDelegate next, ObjectPool<HttpApplication> pool)
-    {
-        _next = next;
-        _pool = pool;
-    }
+    public HttpApplicationMiddleware(RequestDelegate next) => _next = next;
 
     public async Task InvokeAsync(HttpContextCore context)
     {
-        var app = _pool.Get();
-
-        var endFeature = context.Features.GetRequired<IHttpResponseEndFeature>();
-        var httpApplicationFeature = new RequestHttpApplicationFeature(app, endFeature);
-
-        context.Features.Set<IHttpApplicationFeature>(httpApplicationFeature);
-        context.Features.Set<IHttpResponseEndFeature>(httpApplicationFeature);
-        context.Features.Set<IRequestExceptionFeature>(httpApplicationFeature);
+        context.Features.GetRequired<IHttpResponseBufferingFeature>().EnableBuffering(BufferResponseStreamAttribute.DefaultMemoryThreshold, default);
 
         try
         {
-            app.Context = context;
-
-            context.Features.GetRequired<IHttpResponseBufferingFeature>().EnableBuffering(BufferResponseStreamAttribute.DefaultMemoryThreshold, default);
-
-            try
-            {
-                await _next(context);
-            }
-            finally
-            {
-                await context.Features.GetRequired<IHttpResponseEndFeature>().EndAsync();
-            }
+            await _next(context);
         }
         finally
         {
-            context.Features.Set<IHttpResponseEndFeature>(endFeature);
-            context.Features.Set<IHttpApplicationFeature>(null);
-            context.Features.Set<IRequestExceptionFeature>(null);
-
-            _pool.Return(app);
+            await context.Features.GetRequired<IHttpResponseEndFeature>().EndAsync();
         }
     }
 }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpApplication/HttpApplicationOptions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpApplication/HttpApplicationOptions.cs
@@ -40,7 +40,7 @@ public class HttpApplicationOptions
     internal void MakeReadOnly() => _modules.MakeReadOnly();
 
     /// <summary>
-    /// Gets or sets the number of <see cref="HttpApplication"/> retained for reuse. In order to support modules and appplications that may contain state,
+    /// Gets or sets the number of <see cref="HttpApplication"/> retained for reuse. In order to support modules and applications that may contain state,
     /// a unique instance is required for each request. This type should be set to the average number of concurrent requests expected to be seen.
     /// </summary>
     public int PoolSize { get; set; } = 100;

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpApplication/RegisterHttpApplicationFeatureMiddleware.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpApplication/RegisterHttpApplicationFeatureMiddleware.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using System.Web;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.SystemWebAdapters.Features;
+using Microsoft.Extensions.ObjectPool;
+
+namespace Microsoft.AspNetCore.SystemWebAdapters;
+
+internal sealed class RegisterHttpApplicationFeatureMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ObjectPool<HttpApplication> _pool;
+
+    public RegisterHttpApplicationFeatureMiddleware(RequestDelegate next, ObjectPool<HttpApplication> pool)
+    {
+        _next = next;
+        _pool = pool;
+    }
+
+    public async Task InvokeAsync(HttpContextCore context)
+    {
+        var endFeature = context.Features.GetRequired<IHttpResponseEndFeature>();
+        using var httpApplicationFeature = new HttpApplicationFeature(context, endFeature, _pool);
+
+        context.Features.Set<IHttpApplicationFeature>(httpApplicationFeature);
+        context.Features.Set<IHttpResponseEndFeature>(httpApplicationFeature);
+        context.Features.Set<IRequestExceptionFeature>(httpApplicationFeature);
+
+        try
+        {
+            await _next(context);
+        }
+        finally
+        {
+            context.Features.Set<IHttpApplicationFeature>(null);
+            context.Features.Set<IHttpResponseEndFeature>(null);
+            context.Features.Set<IRequestExceptionFeature>(null);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpApplication/RegisterHttpApplicationFeatureMiddleware.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpApplication/RegisterHttpApplicationFeatureMiddleware.cs
@@ -35,8 +35,8 @@ internal sealed class RegisterHttpApplicationFeatureMiddleware
         }
         finally
         {
+            context.Features.Set<IHttpResponseEndFeature>(endFeature);
             context.Features.Set<IHttpApplicationFeature>(null);
-            context.Features.Set<IHttpResponseEndFeature>(null);
             context.Features.Set<IRequestExceptionFeature>(null);
         }
     }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/SystemWebAdaptersExtensions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/SystemWebAdaptersExtensions.cs
@@ -147,6 +147,11 @@ public static class SystemWebAdaptersExtensions
                 builder.UseMiddleware<SetHttpContextTimestampMiddleware>();
                 builder.UseMiddleware<RegisterAdapterFeaturesMiddleware>();
 
+                if (builder.AreHttpApplicationEventsRequired())
+                {
+                    builder.UseMiddleware<RegisterHttpApplicationFeatureMiddleware>();
+                }
+
                 next(builder);
             };
     }


### PR DESCRIPTION
This allows the features for HttpApplication to be insterted in the HttpContext at the beginning of the request, but will only be invoked in the `.UseSystemWebAdapters()` middleware call. This enables a request to potentially modify behavior of the features if needed before invoking the middleware.

A nice side effect of this is that an HttpApplication instance will only be retrieved from the pool if it is actually used within a request, otherwise, it will never be retrieved. This is one of the more expensive parts of the emulated IIS pipeline as we have to assign an HttpApplication to a request, so it can potentially prevent a request from needing to perform this.