### PR TITLE
Use AddWrappedAspNetCoreSession to better fit standard naming

### DIFF
--- a/samples/CoreApp/Program.cs
+++ b/samples/CoreApp/Program.cs
@@ -1,7 +1,7 @@
 var builder = WebApplication.CreateBuilder();
 
 builder.Services.AddSystemWebAdapters()
-    .WrapAspNetCoreSession()
+    .AddWrappedAspNetCoreSession()
     .AddSessionSerializer()
     .AddCustomSerialization();
 

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/SessionState/Wrapped/ISystemWebAdapterBuilderSessionExtensions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/SessionState/Wrapped/ISystemWebAdapterBuilderSessionExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.ComponentModel;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.SystemWebAdapters;
 using Microsoft.AspNetCore.SystemWebAdapters.SessionState.Serialization;
@@ -13,6 +14,7 @@ namespace Microsoft.Extensions.DependencyInjection;
 public static class ISystemWebAdapterBuilderSessionExtensions
 {
     [Obsolete("Prefer AddWrappedAspNetCoreSession instead")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static ISystemWebAdapterBuilder WrapAspNetCoreSession(this ISystemWebAdapterBuilder builder, Action<SessionOptions>? options = null)
         => builder.AddWrappedAspNetCoreSession(options);
 

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/SessionState/Wrapped/ISystemWebAdapterBuilderSessionExtensions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/SessionState/Wrapped/ISystemWebAdapterBuilderSessionExtensions.cs
@@ -12,7 +12,11 @@ namespace Microsoft.Extensions.DependencyInjection;
 
 public static class ISystemWebAdapterBuilderSessionExtensions
 {
+    [Obsolete("Prefer AddWrappedAspNetCoreSession instead")]
     public static ISystemWebAdapterBuilder WrapAspNetCoreSession(this ISystemWebAdapterBuilder builder, Action<SessionOptions>? options = null)
+        => builder.AddWrappedAspNetCoreSession(options);
+
+    public static ISystemWebAdapterBuilder AddWrappedAspNetCoreSession(this ISystemWebAdapterBuilder builder, Action<SessionOptions>? options = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
 

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/SessionState/SessionIntegrationTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/SessionState/SessionIntegrationTests.cs
@@ -66,7 +66,7 @@ public class SessionIntegrationTests
                       services.AddRouting();
                       services.AddControllers();
                       services.AddSystemWebAdapters()
-                        .WrapAspNetCoreSession();
+                        .AddWrappedAspNetCoreSession();
                       services.AddDistributedMemoryCache();
                   })
                   .Configure(app =>


### PR DESCRIPTION
We have a method (WrapAsnnetCoreSession) that wraps the ASP.NET Core session for use with System.Web.SessionState APIs, but this name is not in line with the standard service collection extensions of (`Add...`). This change obsoletes the old one and applies the normal convention.
