### PR TITLE
Missing(Porting) SaveAS API to HttpPostedFile

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
@@ -323,6 +323,7 @@ namespace System.Web
         public virtual string ContentType { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual string FileName { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual System.IO.Stream InputStream { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public virtual void SaveAs(string filename) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
     }
     public partial class HttpPostedFileWrapper : System.Web.HttpPostedFileBase
     {
@@ -331,6 +332,7 @@ namespace System.Web
         public override string ContentType { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override string FileName { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override System.IO.Stream InputStream { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public override void SaveAs(string filename) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
     }
     public partial class HttpRequest
     {

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
@@ -314,6 +314,7 @@ namespace System.Web
         public string ContentType { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public string FileName { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public System.IO.Stream InputStream { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public void SaveAs(string filename) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
     }
     public abstract partial class HttpPostedFileBase
     {

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpPostedFile.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpPostedFile.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using System.IO;
 using Microsoft.AspNetCore.Http;
 
@@ -19,4 +20,18 @@ public sealed class HttpPostedFile
     public int ContentLength => (int)File.Length;
 
     public Stream InputStream => File.OpenReadStream();
+
+    public void SaveAs(string filename)
+    {
+        if (!Path.IsPathRooted(filename))
+        {
+            throw new HttpException(string.Format(CultureInfo.InvariantCulture,
+                "The SaveAs method is configured to require a rooted path, and the path '{0}' is not rooted", filename));
+        }
+
+        using (var fileStream = new FileStream(filename, FileMode.Create))
+        {
+            InputStream.CopyTo(fileStream);
+        }
+    }
 }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpPostedFileBase.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpPostedFileBase.cs
@@ -15,4 +15,6 @@ public abstract class HttpPostedFileBase
     public virtual int ContentLength => throw new NotImplementedException();
 
     public virtual Stream InputStream => throw new NotImplementedException();
+
+    public virtual void SaveAs(string filename) => throw new NotImplementedException(); 
 }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpPostedFileWrapper.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpPostedFileWrapper.cs
@@ -23,4 +23,6 @@ public class HttpPostedFileWrapper : HttpPostedFileBase
     public override string FileName => _file.FileName;
 
     public override Stream InputStream => _file.InputStream;
+
+    public override void SaveAs(string filename) => _file.SaveAs(filename);
 }

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpPostedFileTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/HttpPostedFileTests.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
+using System;
 using System.IO;
 using System.Web;
 using AutoFixture;
@@ -99,5 +101,38 @@ public class HttpPostedFileTests
 
         // Assert
         Assert.Equal(expected.Object, stream);
+    }
+
+    [Fact]
+    public void SaveAsForInvalidRootPath()
+    {
+        // Arrange
+        var file = new Mock<IFormFile>();
+        var expectedStream = new Mock<Stream>();
+        file.Setup(f => f.OpenReadStream()).Returns(expectedStream.Object);
+        var posted = new HttpPostedFile(file.Object);
+
+        //Act and Assert
+        Assert.Throws<HttpException>(() => posted.SaveAs("InvalidPath"));
+    }
+
+    [Fact]
+    public void SaveAsWithValidRootPath()
+    {
+        // Arrange
+        var file = new Mock<IFormFile>();
+        var expectedStream = new Mock<Stream>();
+        file.Setup(f => f.OpenReadStream()).Returns(expectedStream.Object);
+        string validTempPath = string.Format(CultureInfo.InvariantCulture, @"{0}{1}.txt", Path.GetTempPath(), Guid.NewGuid());
+        var posted = new HttpPostedFile(file.Object);
+
+        //Act
+        posted.SaveAs(validTempPath);
+
+        //Assert
+        Assert.True(File.Exists(validTempPath), "Temp file should be created");
+
+        //Cleanup
+        File.Delete(validTempPath);
     }
 }


### PR DESCRIPTION
This will bring the SaveAS  API to HttpPostedFile, which will be used in FileUpload control https://github.com/CoreWebForms/CoreWebForms/issues/29

Fixes #451