### PR TITLE
Ensure SessionAttribute defaults to same behavior as 1.2

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/SessionAttribute.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/SessionAttribute.cs
@@ -33,7 +33,7 @@ public sealed class SessionAttribute : Attribute
         }
     }
 
-    public SessionStateBehavior SessionBehavior { get; set; }
+    public SessionStateBehavior SessionBehavior { get; set; } = SessionStateBehavior.Required;
 
     public bool IsPreLoad { get; set; } = true;
 

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/SessionState/SessionIntegrationTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/SessionState/SessionIntegrationTests.cs
@@ -31,6 +31,7 @@ public class SessionIntegrationTests
 
     [InlineData("/disabled", "Session:null")]
     [InlineData("/readonly", "ReadOnly:True")]
+    [InlineData("/session", "ReadOnly:False")]
     [InlineData("/required", "ReadOnly:False")]
     [InlineData("/default", "Session:null")]
     [Theory]
@@ -82,6 +83,7 @@ public class SessionIntegrationTests
                       app.UseEndpoints(endpoints =>
                       {
                           endpoints.MapGet("/", (context) => GetSessionStatus(context));
+                          endpoints.MapGet("/session", (context) => GetSessionStatus(context)).RequireSystemWebAdapterSession();
                           endpoints.MapGet("/disabled", (context) => GetSessionStatus(context)).WithMetadata(new SessionAttribute { SessionBehavior = SessionStateBehavior.Disabled });
                           endpoints.MapGet("/readonly", (context) => GetSessionStatus(context)).WithMetadata(new SessionAttribute { SessionBehavior = SessionStateBehavior.ReadOnly });
                           endpoints.MapGet("/required", (context) => GetSessionStatus(context)).WithMetadata(new SessionAttribute { SessionBehavior = SessionStateBehavior.Required });


### PR DESCRIPTION
As part of expanding the session support to enable per request changing the session behavior in #399, it appears that the default `SessionAttribute` was changed to have a different default value.

Fixes #455
