### PR TITLE
Switch packages version to 1.3.1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -6,7 +6,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <MajorVersion>1</MajorVersion>
-    <MinorVersion>4</MinorVersion>
+    <MinorVersion>3</MinorVersion>
+    <PatchVersion>1</PatchVersion>
     <PreReleaseVersionLabel>preview.1</PreReleaseVersionLabel>
     <DotNetFinalVersionKind Condition="'$(PreReleaseVersionLabel)' == 'rtw'">release</DotNetFinalVersionKind>
   </PropertyGroup>


### PR DESCRIPTION
FYI @twsouthwick 

As discussed, switching our builds to produce 1.3.1 as opposed to 1.4.0 so that we are ready to ship a new servicing package with our latest fixes.
