### PR TITLE
Prefer IHttpContextAccessor over HttpContextAccessor

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Hosting/HostingEnvironmentAccessor.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Hosting/HostingEnvironmentAccessor.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.SystemWebAdapters;
 using Microsoft.Extensions.DependencyInjection;
@@ -11,7 +12,7 @@ namespace System.Web.Hosting;
 
 internal sealed class HostingEnvironmentAccessor
 {
-    private static readonly HttpContextAccessor _defaultHttpContextAccessor = new();
+    private static HttpContextAccessor? _defaultHttpContextAccessor;
     private static HostingEnvironmentAccessor? _current;
 
     private readonly IOptions<SystemWebAdaptersOptions> _options;
@@ -50,7 +51,23 @@ internal sealed class HostingEnvironmentAccessor
     /// <summary>
     /// Gets an <see cref="IHttpContextAccessor"/> that is either registered to the current hosting runtime or the default one via <see cref="HttpContextAccessor"/>.  
     /// </summary>
-    public static IHttpContextAccessor HttpContextAccessor => _current?._accessor ?? _defaultHttpContextAccessor;
+    public static IHttpContextAccessor HttpContextAccessor
+    {
+        get
+        {
+            if (_current?._accessor is { } current)
+            {
+                return current;
+            }
+
+            if (_defaultHttpContextAccessor is null)
+            {
+                Interlocked.CompareExchange(ref _defaultHttpContextAccessor, new(), null);
+            }
+
+            return _defaultHttpContextAccessor;
+        }
+    }
 
     internal SystemWebAdaptersOptions Options => _options.Value;
 }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Hosting/HostingEnvironmentAccessor.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Hosting/HostingEnvironmentAccessor.cs
@@ -2,20 +2,25 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.SystemWebAdapters;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace System.Web.Hosting;
 
 internal sealed class HostingEnvironmentAccessor
 {
+    private static readonly HttpContextAccessor _defaultHttpContextAccessor = new();
     private static HostingEnvironmentAccessor? _current;
 
     private readonly IOptions<SystemWebAdaptersOptions> _options;
+    private readonly IHttpContextAccessor? _accessor;
 
     public HostingEnvironmentAccessor(IServiceProvider services, IOptions<SystemWebAdaptersOptions> options)
     {
         Services = services;
+        _accessor = services.GetService<IHttpContextAccessor>();
         _options = options;
     }
 
@@ -41,6 +46,11 @@ internal sealed class HostingEnvironmentAccessor
         current = _current;
         return current is not null;
     }
+
+    /// <summary>
+    /// Gets an <see cref="IHttpContextAccessor"/> that is either registered to the current hosting runtime or the default one via <see cref="HttpContextAccessor"/>.  
+    /// </summary>
+    public static IHttpContextAccessor HttpContextAccessor => _current?._accessor ?? _defaultHttpContextAccessor;
 
     internal SystemWebAdaptersOptions Options => _options.Value;
 }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpContext.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpContext.cs
@@ -9,7 +9,6 @@ using System.Web.Caching;
 using System.Web.Hosting;
 using System.Web.SessionState;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features.Authentication;
 using Microsoft.AspNetCore.SystemWebAdapters;
 using Microsoft.AspNetCore.SystemWebAdapters.Features;
@@ -21,8 +20,6 @@ namespace System.Web;
 
 public class HttpContext : IServiceProvider
 {
-    private static readonly HttpContextAccessor _defaultHttpContextAccessor = new();
-
     private HttpRequest? _request;
     private HttpResponse? _response;
     private HttpServerUtility? _server;
@@ -31,21 +28,8 @@ public class HttpContext : IServiceProvider
 
     public static HttpContext? Current
     {
-        get => Accessor.HttpContext?.AsSystemWeb();
-        set => Accessor.HttpContext = value?.AsAspNetCore();
-    }
-
-    private static IHttpContextAccessor Accessor
-    {
-        get
-        {
-            if (HostingEnvironmentAccessor.TryGet(out var current) && current.Services.GetService<IHttpContextAccessor>() is { } accessor)
-            {
-                return accessor;
-            }
-
-            return _defaultHttpContextAccessor;
-        }
+        get => HostingEnvironmentAccessor.HttpContextAccessor.HttpContext?.AsSystemWeb();
+        set => HostingEnvironmentAccessor.HttpContextAccessor.HttpContext = value?.AsAspNetCore();
     }
 
     internal HttpContext(HttpContextCore context)

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/HttpContextCurrentTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/HttpContextCurrentTests.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests;
+
+[Collection(nameof(SelfHostedTests))]
+public class HttpContextCurrentTests
+{
+    [Fact]
+    public void CurrentReturnsNullByDefault()
+    {
+        Assert.Null(HttpContext.Current);
+    }
+
+    [Fact]
+    public void SavesByDefaultToHttpContextAccessor()
+    {
+        // Arrange
+        var accessor = new HttpContextAccessor();
+        var context = new DefaultHttpContext();
+
+        // Act
+        HttpContext.Current = context;
+
+        // Assert
+        Assert.Same(accessor.HttpContext, context);
+    }
+
+    [Fact]
+    public async Task UsesIHttpContextAccessor()
+    {
+        // Arrange
+        var defaultAccessor = new HttpContextAccessor();
+        var accessor = new Mock<IHttpContextAccessor>();
+        accessor.SetupAllProperties();
+
+        using var host = await new HostBuilder()
+           .ConfigureWebHost(webBuilder =>
+           {
+               webBuilder
+                   .UseTestServer()
+                   .ConfigureServices(services =>
+                   {
+                       services.AddSingleton(accessor.Object);
+                       services.AddSystemWebAdapters();
+                   })
+                   .Configure(app =>
+                   {
+                   });
+           })
+           .StartAsync();
+        var context = new DefaultHttpContext();
+
+        // Act
+        HttpContext.Current = context;
+
+        // Assert
+        Assert.Same(context, accessor.Object.HttpContext);
+        Assert.Null(defaultAccessor.HttpContext);
+    }
+}

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/HttpContextCurrentTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/HttpContextCurrentTests.cs
@@ -39,7 +39,6 @@ public class HttpContextCurrentTests
     public async Task UsesIHttpContextAccessor()
     {
         // Arrange
-        var defaultAccessor = new HttpContextAccessor();
         var accessor = new Mock<IHttpContextAccessor>();
         accessor.SetupAllProperties();
 
@@ -65,6 +64,6 @@ public class HttpContextCurrentTests
 
         // Assert
         Assert.Same(context, accessor.Object.HttpContext);
-        Assert.Null(defaultAccessor.HttpContext);
+        Assert.Null(new HttpContextAccessor().HttpContext);
     }
 }

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/ResponseHeaderTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/ResponseHeaderTests.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Net.Http.Headers;
 using Xunit;
+
 using SameSiteMode = System.Web.SameSiteMode;
 
 namespace Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests;


### PR DESCRIPTION
This change will check if we're currently in a runtime environment that contains a IHttpContextAccessor; if we are, then we'll prefer that over HttpContextAccessor. This allows people to potentially customize what it means to get and set a HttpContext.