### PR TITLE
Add HttpRuntime.WebObjectActivator

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/ExcludedApis.txt
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/ExcludedApis.txt
@@ -27,3 +27,7 @@ T:System.Web.IHtmlString
 T:System.Web.HtmlString
 
 T:Microsoft.AspNetCore.SystemWebAdapters.ITraceContext
+
+# Only available .NET 4.7.2+
+P:System.Web.HttpRuntime.WebObjectActivator
+ 

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpRuntime.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpRuntime.cs
@@ -17,5 +17,7 @@ public sealed class HttpRuntime
 
     public static string AppDomainAppPath => HostingEnvironmentAccessor.Current.Options.AppDomainAppPath;
 
-    public static Cache Cache => HostingEnvironmentAccessor.Current.Services.GetRequiredService<Cache>();
+    public static IServiceProvider WebObjectActivator => HostingEnvironmentAccessor.Current.Services;
+
+    public static Cache Cache => WebObjectActivator.GetRequiredService<Cache>();
 }


### PR DESCRIPTION
This API is only available .NET 4.7.2, so it won't be avaliable .NET Standard.
