### PR TITLE
Ensure response can be buffered if already buffered

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Features/HttpResponseAdapterFeature.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Features/HttpResponseAdapterFeature.cs
@@ -58,7 +58,11 @@ internal class HttpResponseAdapterFeature :
 
     void IHttpResponseBufferingFeature.EnableBuffering(int memoryThreshold, long? bufferLimit)
     {
-        if (_state == StreamState.NotStarted)
+        if (_state == StreamState.Buffering)
+        {
+            return;
+        }
+        else if (_state == StreamState.NotStarted)
         {
             Debug.Assert(_bufferedStream is null);
 

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/InputStreamTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/InputStreamTests.cs
@@ -7,6 +7,8 @@ using System.Threading.Tasks;
 using System.Web;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.SystemWebAdapters.Features;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -77,6 +79,24 @@ public partial class InputStreamTests
         {
             context.Request.InputStream.CopyTo(context.Response.OutputStream);
         }, builder => builder.PreBufferRequestStream());
+
+        // Assert
+        Assert.Equal(ContentValue, result);
+    }
+
+    [Fact]
+    public async Task BufferMultipleTimes()
+    {
+        // Act
+        var result = await RunAsync(ContentValue, async context =>
+        {
+            var feature = context.AsAspNetCore().Features.GetRequired<IHttpRequestInputStreamFeature>();
+
+            await feature.BufferInputStreamAsync(default);
+            await feature.BufferInputStreamAsync(default);
+
+            context.Request.InputStream.CopyTo(context.Response.OutputStream);
+        });
 
         // Assert
         Assert.Equal(ContentValue, result);

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/ResponseStreamTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/ResponseStreamTests.cs
@@ -5,9 +5,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.SystemWebAdapters.Features;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -210,6 +212,25 @@ public class ResponseStreamTests
         }, builder => builder.BufferResponseStream());
 
         Assert.Equal("part4", result);
+    }
+
+    [Fact]
+    public async Task BufferMultipleTimes()
+    {
+        const string Result = "text";
+
+        // Act
+        var result = await RunAsync(context =>
+        {
+            var feature = context.AsAspNetCore().Features.GetRequired<IHttpResponseBufferingFeature>();
+
+            feature.EnableBuffering(1024, default);
+            feature.EnableBuffering(1024, default);
+
+            context.Response.Write(Result);
+        });
+
+        Assert.Equal(Result, result);
     }
 
     [Fact]


### PR DESCRIPTION
There are times where buffering may be called but it is already buffering and so it would throw. Now, if it is already buffering, it will gracefully continue.
