### PR TITLE
Ensure *Base types have the same members as the main types

### DIFF
--- a/Microsoft.AspNetCore.SystemWebAdapters.slnf
+++ b/Microsoft.AspNetCore.SystemWebAdapters.slnf
@@ -6,10 +6,11 @@
       "src\\Microsoft.AspNetCore.SystemWebAdapters.CoreServices\\Microsoft.AspNetCore.SystemWebAdapters.CoreServices.csproj",
       "src\\Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices\\Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices.csproj",
       "src\\Microsoft.AspNetCore.SystemWebAdapters\\Microsoft.AspNetCore.SystemWebAdapters.csproj",
+      "test\\Microsoft.AspNetCore.SystemWebAdapters.Apis.Tests\\Microsoft.AspNetCore.SystemWebAdapters.Apis.Tests.csproj",
       "test\\Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests\\Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests.csproj",
       "test\\Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices.Tests\\Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices.Tests.csproj",
-      "test\\Microsoft.AspNetCore.SystemWebAdapters.Tests\\Microsoft.AspNetCore.SystemWebAdapters.Tests.csproj",
       "test\\Microsoft.AspNetCore.SystemWebAdapters.NuGet.Tests\\Microsoft.AspNetCore.SystemWebAdapters.NuGet.Tests.csproj",
+      "test\\Microsoft.AspNetCore.SystemWebAdapters.Tests\\Microsoft.AspNetCore.SystemWebAdapters.Tests.csproj",
       "test\\Samples.MVCApp.Tests\\Samples.MVCApp.Tests.csproj",
       "test\\Samples.RemoteAuth.Forms.Tests\\Samples.RemoteAuth.Forms.Tests.csproj"
     ]

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
@@ -187,9 +187,11 @@ namespace System.Web
         public virtual System.Web.HttpServerUtilityBase Server { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual System.Web.HttpSessionStateBase Session { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual System.DateTime Timestamp { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public virtual System.Web.TraceContext Trace { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual System.Security.Principal.IPrincipal User { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual void AddError(System.Exception ex) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public virtual void ClearError() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        public virtual System.Web.ISubscriptionToken DisposeOnPipelineCompleted(System.IDisposable target) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public virtual object GetService(System.Type serviceType) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public virtual void RemapHandler(System.Web.IHttpHandler handler) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public virtual void RewritePath(string path) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
@@ -218,9 +220,11 @@ namespace System.Web
         public override System.Web.HttpServerUtilityBase Server { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override System.Web.HttpSessionStateBase Session { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override System.DateTime Timestamp { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public override System.Web.TraceContext Trace { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override System.Security.Principal.IPrincipal User { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override void AddError(System.Exception ex) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public override void ClearError() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        public override System.Web.ISubscriptionToken DisposeOnPipelineCompleted(System.IDisposable target) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public override object GetService(System.Type serviceType) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public override void RemapHandler(System.Web.IHttpHandler handler) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public override void RewritePath(string path) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
@@ -404,6 +408,8 @@ namespace System.Web
         public virtual int ContentLength { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual string ContentType { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual System.Web.HttpCookieCollection Cookies { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public virtual string CurrentExecutionFilePath { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public virtual string FilePath { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual System.Web.HttpFileCollectionBase Files { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual System.Collections.Specialized.NameValueCollection Form { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual System.Collections.Specialized.NameValueCollection Headers { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
@@ -416,9 +422,11 @@ namespace System.Web
         public virtual System.Security.Principal.IIdentity LogonUserIdentity { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual System.Collections.Specialized.NameValueCollection Params { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual string Path { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public virtual string PathInfo { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual string PhysicalPath { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual System.Collections.Specialized.NameValueCollection QueryString { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual string RawUrl { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public virtual System.Web.ReadEntityBodyMode ReadEntityBodyMode { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual string RequestType { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual System.Collections.Specialized.NameValueCollection ServerVariables { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual int TotalBytes { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
@@ -432,6 +440,7 @@ namespace System.Web
         public virtual byte[] BinaryRead(int count) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public virtual System.IO.Stream GetBufferedInputStream() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public virtual System.IO.Stream GetBufferlessInputStream() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        public virtual void SaveAs(string filename, bool includeHeaders) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
     }
     public partial class HttpRequestWrapper : System.Web.HttpRequestBase
     {
@@ -444,6 +453,8 @@ namespace System.Web
         public override int ContentLength { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override string ContentType { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override System.Web.HttpCookieCollection Cookies { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public override string CurrentExecutionFilePath { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public override string FilePath { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override System.Web.HttpFileCollectionBase Files { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override System.Collections.Specialized.NameValueCollection Form { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override System.Collections.Specialized.NameValueCollection Headers { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
@@ -456,9 +467,11 @@ namespace System.Web
         public override System.Security.Principal.IIdentity LogonUserIdentity { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override System.Collections.Specialized.NameValueCollection Params { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override string Path { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public override string PathInfo { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override string PhysicalPath { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override System.Collections.Specialized.NameValueCollection QueryString { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override string RawUrl { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public override System.Web.ReadEntityBodyMode ReadEntityBodyMode { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override string RequestType { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override System.Collections.Specialized.NameValueCollection ServerVariables { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override int TotalBytes { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
@@ -472,6 +485,7 @@ namespace System.Web
         public override byte[] BinaryRead(int count) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public override System.IO.Stream GetBufferedInputStream() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public override System.IO.Stream GetBufferlessInputStream() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        public override void SaveAs(string filename, bool includeHeaders) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
     }
     public partial class HttpResponse
     {
@@ -533,6 +547,7 @@ namespace System.Web
         public virtual bool IsRequestBeingRedirected { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual System.IO.TextWriter Output { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual System.IO.Stream OutputStream { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public virtual string RedirectLocation { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual int StatusCode { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual string StatusDescription { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual int SubStatusCode { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
@@ -546,6 +561,8 @@ namespace System.Web
         public virtual void ClearContent() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public virtual void ClearHeaders() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public virtual void End() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        public virtual void Flush() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        public virtual System.Threading.Tasks.Task FlushAsync() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public virtual void Redirect(string url) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public virtual void Redirect(string url, bool endResponse) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public virtual void RedirectPermanent(string url) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
@@ -574,6 +591,7 @@ namespace System.Web
         public override bool IsRequestBeingRedirected { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override System.IO.TextWriter Output { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override System.IO.Stream OutputStream { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public override string RedirectLocation { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override int StatusCode { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override string StatusDescription { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override int SubStatusCode { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
@@ -587,6 +605,8 @@ namespace System.Web
         public override void ClearContent() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public override void ClearHeaders() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public override void End() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        public override void Flush() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        public override System.Threading.Tasks.Task FlushAsync() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public override void Redirect(string url) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public override void Redirect(string url, bool endResponse) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public override void RedirectPermanent(string url) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpContextBase.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpContextBase.cs
@@ -26,6 +26,10 @@ namespace System.Web
         [SuppressMessage("Performance", "CA1819:Properties should not return arrays", Justification = Constants.ApiFromAspNet)]
         public virtual Exception[] AllErrors => throw new NotImplementedException();
 
+        public virtual TraceContext Trace => throw new NotImplementedException();
+
+        public virtual ISubscriptionToken DisposeOnPipelineCompleted(IDisposable target) => throw new NotImplementedException();
+
         public virtual void ClearError() => throw new NotImplementedException();
 
         public virtual void AddError(Exception ex) => throw new NotImplementedException();

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpContextWrapper.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpContextWrapper.cs
@@ -80,6 +80,10 @@ namespace System.Web
             set => _context.Handler = value;
         }
 
+        public override ISubscriptionToken DisposeOnPipelineCompleted(IDisposable target) => _context.DisposeOnPipelineCompleted(target);
+
+        public override TraceContext Trace => _context.Trace;
+
         public override IHttpHandler? PreviousHandler => _context.PreviousHandler;
 
         public override void RemapHandler(IHttpHandler handler) => _context.RemapHandler(handler);

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpRequestBase.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpRequestBase.cs
@@ -18,7 +18,17 @@ namespace System.Web
 
         public virtual string Path => throw new NotImplementedException();
 
+        public virtual string PathInfo => throw new NotImplementedException();
+
+        public virtual string CurrentExecutionFilePath => throw new NotImplementedException();
+
         public virtual string? PhysicalPath => throw new NotImplementedException();
+
+        public virtual string? FilePath => throw new NotImplementedException();
+
+        public virtual ReadEntityBodyMode ReadEntityBodyMode => throw new NotImplementedException();
+
+        public virtual void SaveAs(string filename, bool includeHeaders) => throw new NotImplementedException();
 
         public virtual NameValueCollection Headers => throw new NotImplementedException();
 

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpRequestWrapper.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpRequestWrapper.cs
@@ -59,7 +59,13 @@ namespace System.Web
 
         public override string Path => _request.Path;
 
+        public override string CurrentExecutionFilePath => _request.CurrentExecutionFilePath;
+
+        public override string PathInfo => _request.PathInfo;
+
         public override string? PhysicalPath => _request.PhysicalPath;
+
+        public override string? FilePath => _request.FilePath;
 
         public override NameValueCollection QueryString => _request.QueryString;
 
@@ -92,6 +98,10 @@ namespace System.Web
         public override NameValueCollection ServerVariables => _request.ServerVariables;
 
         public override NameValueCollection Params => _request.Params;
+
+        public override ReadEntityBodyMode ReadEntityBodyMode => _request.ReadEntityBodyMode;
+
+        public override void SaveAs(string filename, bool includeHeaders) => _request.SaveAs(filename, includeHeaders);
 
         public override string? this[string key] => _request[key];
     }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponseBase.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponseBase.cs
@@ -5,6 +5,7 @@ using System.Collections.Specialized;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.SystemWebAdapters;
 
 namespace System.Web
@@ -63,7 +64,7 @@ namespace System.Web
             set => throw new NotImplementedException();
         }
 
-        public virtual bool BufferOutput  => throw new NotImplementedException();
+        public virtual bool BufferOutput => throw new NotImplementedException();
 
         public virtual Stream OutputStream => throw new NotImplementedException();
 
@@ -123,6 +124,10 @@ namespace System.Web
 
         public virtual void ClearHeaders() => throw new NotImplementedException();
 
+        public virtual void Flush() => throw new NotImplementedException();
+
+        public virtual Task FlushAsync() => throw new NotImplementedException();
+
         public virtual void WriteFile(string filename) => throw new NotImplementedException();
 
         public virtual void TransmitFile(string filename) => throw new NotImplementedException();
@@ -141,6 +146,12 @@ namespace System.Web
 
         [SuppressMessage("Design", "CA1054:URI parameters should not be strings", Justification = Constants.ApiFromAspNet)]
         public virtual void RedirectPermanent(string url, bool endResponse) => throw new NotImplementedException();
+
+        public virtual string? RedirectLocation
+        {
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
+        }
 
         [return: NotNullIfNotNull(nameof(response))]
         public static implicit operator HttpResponseBase?(HttpResponseCore? response) => response?.HttpContext.AsSystemWebBase().Response;

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponseWrapper.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponseWrapper.cs
@@ -5,7 +5,7 @@ using System.Collections.Specialized;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
-using Microsoft.AspNetCore.Http;
+using System.Threading.Tasks;
 
 namespace System.Web
 {
@@ -122,6 +122,10 @@ namespace System.Web
 
         public override void ClearHeaders() => _response.ClearHeaders();
 
+        public override void Flush() => _response.Flush();
+
+        public override Task FlushAsync() => _response.FlushAsync();
+
         public override void End() => _response.End();
 
         public override void TransmitFile(string filename) => _response.TransmitFile(filename);
@@ -143,5 +147,10 @@ namespace System.Web
         [SuppressMessage("Design", "CA1054:URI parameters should not be strings", Justification = Constants.ApiFromAspNet)]
         public override void RedirectPermanent(string url, bool endResponse) => _response.RedirectPermanent(url, endResponse);
 
+        public override string? RedirectLocation
+        {
+            get => _response.RedirectLocation;
+            set => _response.RedirectLocation = value;
+        }
     }
 }

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Apis.Tests/TypeCollector.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Apis.Tests/TypeCollector.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis;
 
 namespace Microsoft.AspNetCore.SystemWebAdapters;
 
-internal class TypeCollector : SymbolVisitor
+internal sealed class TypeCollector : SymbolVisitor
 {
     private HashSet<string> Members { get; } = new HashSet<string>();
 

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Apis.Tests/VerifyHttpBaseTypes.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Apis.Tests/VerifyHttpBaseTypes.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Web;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.AspNetCore.SystemWebAdapters;
+
+/// <summary>
+/// This test validates that the *Base type (the abstraction in System.Web) has the same members as on the non-base type. For example, <see cref="HttpContext"/> and <see cref="HttpContextBase"/>.
+/// This test is a best effort to ensure when an API is added to the main type, the base type gets it as well
+/// </summary>
+public class VerifyHttpBaseTypes
+{
+    private static readonly HashSet<string> _skipped = new HashSet<string>()
+    {
+        "op_Implicit", // This is only defined on the non-base types as there is a well defined conversion
+    };
+
+    private readonly ITestOutputHelper _output;
+
+    public VerifyHttpBaseTypes(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [InlineData(typeof(HttpContext), typeof(HttpContextBase))]
+    [InlineData(typeof(HttpRequest), typeof(HttpRequestBase))]
+    [InlineData(typeof(HttpResponse), typeof(HttpResponseBase))]
+    [Theory]
+    public void ValidateMemberExistsOnBaseType(Type type, Type baseType)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+        ArgumentNullException.ThrowIfNull(baseType);
+
+        const BindingFlags Flags = BindingFlags.Public | BindingFlags.Instance;
+
+        var isMissing = false;
+
+        foreach (var method in type.GetMethods(Flags))
+        {
+            if (_skipped.Contains(method.Name))
+            {
+                continue;
+            }
+
+            var found = baseType.GetMethod(method.Name, Flags, method.GetParameters().Select(p => p.ParameterType).ToArray());
+
+            if (found is null)
+            {
+                _output.WriteLine(method.Name);
+                isMissing = true;
+            }
+        }
+
+        Assert.False(isMissing);
+    }
+}

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Apis.Tests/VerifyTypeForwards.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Apis.Tests/VerifyTypeForwards.cs
@@ -12,6 +12,54 @@ using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.SystemWebAdapters;
 
+/// <summary>
+/// This test validates that the *Base type (the abstraction in System.Web) has the same members as on the non-base type. For example, <see cref="HttpContext"/> and <see cref="HttpContextBase"/>.
+/// This test is a best effort to ensure when an API is added to the main type, the base type gets it as well
+/// </summary>
+public class VerifyHttpBaseTypes
+{
+    private static readonly HashSet<string> _skipped = new HashSet<string>()
+    {
+        "op_Implicit", // This is only defined on the non-base types as there is a well defined conversion
+    };
+
+    private readonly ITestOutputHelper _output;
+
+    public VerifyHttpBaseTypes(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [InlineData(typeof(HttpContext), typeof(HttpContextBase))]
+    [InlineData(typeof(HttpRequest), typeof(HttpRequestBase))]
+    [InlineData(typeof(HttpResponse), typeof(HttpResponseBase))]
+    [Theory]
+    public void ValidateMemberExistsOnBaseType(Type type, Type baseType)
+    {
+        const BindingFlags Flags = BindingFlags.Public | BindingFlags.Instance;
+
+        var isMissing = false;
+
+        foreach (var method in type.GetMethods(Flags))
+        {
+            if (_skipped.Contains(method.Name))
+            {
+                continue;
+            }
+
+            var found = baseType.GetMethod(method.Name, Flags, method.GetParameters().Select(p => p.ParameterType).ToArray());
+
+            if (found is null)
+            {
+                _output.WriteLine(method.Name);
+                isMissing = true;
+            }
+        }
+
+        Assert.False(isMissing);
+    }
+}
+
 public class VerifyTypeForwards
 {
     private readonly ITestOutputHelper _output;

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Apis.Tests/VerifyTypeForwards.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Apis.Tests/VerifyTypeForwards.cs
@@ -12,54 +12,6 @@ using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.SystemWebAdapters;
 
-/// <summary>
-/// This test validates that the *Base type (the abstraction in System.Web) has the same members as on the non-base type. For example, <see cref="HttpContext"/> and <see cref="HttpContextBase"/>.
-/// This test is a best effort to ensure when an API is added to the main type, the base type gets it as well
-/// </summary>
-public class VerifyHttpBaseTypes
-{
-    private static readonly HashSet<string> _skipped = new HashSet<string>()
-    {
-        "op_Implicit", // This is only defined on the non-base types as there is a well defined conversion
-    };
-
-    private readonly ITestOutputHelper _output;
-
-    public VerifyHttpBaseTypes(ITestOutputHelper output)
-    {
-        _output = output;
-    }
-
-    [InlineData(typeof(HttpContext), typeof(HttpContextBase))]
-    [InlineData(typeof(HttpRequest), typeof(HttpRequestBase))]
-    [InlineData(typeof(HttpResponse), typeof(HttpResponseBase))]
-    [Theory]
-    public void ValidateMemberExistsOnBaseType(Type type, Type baseType)
-    {
-        const BindingFlags Flags = BindingFlags.Public | BindingFlags.Instance;
-
-        var isMissing = false;
-
-        foreach (var method in type.GetMethods(Flags))
-        {
-            if (_skipped.Contains(method.Name))
-            {
-                continue;
-            }
-
-            var found = baseType.GetMethod(method.Name, Flags, method.GetParameters().Select(p => p.ParameterType).ToArray());
-
-            if (found is null)
-            {
-                _output.WriteLine(method.Name);
-                isMissing = true;
-            }
-        }
-
-        Assert.False(isMissing);
-    }
-}
-
 public class VerifyTypeForwards
 {
     private readonly ITestOutputHelper _output;


### PR DESCRIPTION
System.Web had *Base types that were meant for abstraction. This adds a test to ensure we have the same members on both versions and adds a few that were missing.