### PR TITLE
Fix the ability to disable buffering

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Features/HttpResponseAdapterFeature.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Features/HttpResponseAdapterFeature.cs
@@ -47,7 +47,7 @@ internal class HttpResponseAdapterFeature :
 
     Task IHttpResponseBodyFeature.CompleteAsync() => CompleteAsync();
 
-    void IHttpResponseBodyFeature.DisableBuffering()
+    public void DisableBuffering()
     {
         _responseBodyFeature.DisableBuffering();
         _state = StreamState.NotBuffering;
@@ -65,7 +65,7 @@ internal class HttpResponseAdapterFeature :
         }
     }
 
-    void IHttpResponseBufferingFeature.EnableBuffering(int memoryThreshold, long? bufferLimit)
+    void IHttpResponseBufferingFeature.EnableBuffering(int? memoryThreshold, long? bufferLimit)
     {
         if (_state == StreamState.Buffering)
         {
@@ -76,7 +76,7 @@ internal class HttpResponseAdapterFeature :
             Debug.Assert(_bufferedStream is null);
 
             _state = StreamState.Buffering;
-            _factory = () => new FileBufferingWriteStream(memoryThreshold, bufferLimit);
+            _factory = () => new FileBufferingWriteStream(memoryThreshold ?? PreBufferRequestStreamAttribute.DefaultBufferThreshold, bufferLimit);
         }
         else
         {

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Features/HttpResponseAdapterFeature.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Features/HttpResponseAdapterFeature.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Buffers;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -48,10 +49,18 @@ internal class HttpResponseAdapterFeature :
 
     void IHttpResponseBodyFeature.DisableBuffering()
     {
-        if (_state == StreamState.NotStarted)
+        _responseBodyFeature.DisableBuffering();
+        _state = StreamState.NotBuffering;
+
+        // If anything is already buffered, we'll use a custom pipe that will
+        // clear out the buffer the next time flush is called since this method
+        // is not async
+        if (_bufferedStream is { })
         {
-            _state = StreamState.NotBuffering;
-            _responseBodyFeature.DisableBuffering();
+            _pipeWriter = new FlushingBufferedPipeWriter(this, _responseBodyFeature.Writer);
+        }
+        else
+        {
             _pipeWriter = _responseBodyFeature.Writer;
         }
     }
@@ -100,22 +109,35 @@ internal class HttpResponseAdapterFeature :
             await _pipeWriter.FlushAsync();
         }
 
-        if (_state is StreamState.Buffering && _bufferedStream is not null && !SuppressContent)
+        if (_state is StreamState.Buffering)
+        {
+            await DrainStreamAsync(default);
+        }
+    }
+
+    private async ValueTask DrainStreamAsync(CancellationToken token)
+    {
+        if (_bufferedStream is null)
+        {
+            return;
+        }
+
+        if (!SuppressContent)
         {
             if (_filter is { } filter)
             {
-                await _bufferedStream.DrainBufferAsync(filter);
+                await _bufferedStream.DrainBufferAsync(filter, token);
                 await filter.DisposeAsync();
                 _filter = null;
             }
             else
             {
-                await _bufferedStream.DrainBufferAsync(_responseBodyFeature.Stream);
+                await _bufferedStream.DrainBufferAsync(_responseBodyFeature.Stream, token);
             }
-
-            await _bufferedStream.DisposeAsync();
-            _bufferedStream = null;
         }
+
+        await _bufferedStream.DisposeAsync();
+        _bufferedStream = null;
     }
 
     Stream IHttpResponseBodyFeature.Stream => this;
@@ -286,4 +308,92 @@ internal class HttpResponseAdapterFeature :
 
     public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         => CurrentStream.WriteAsync(buffer, offset, count, cancellationToken);
+
+    /// <summary>
+    /// A <see cref="PipeWriter"/> that can flush any existing buffered items before writing next sequence of bytes
+    /// Intended to be used if <see cref="IHttpResponseBodyFeature.DisableBuffering"/> is called and data has been buffered
+    /// to ensure that the final output will be ordered correctly (since we can't asynchronously write the data in that call).
+    /// </summary>
+    /// <remarks>
+    /// Calls to <see cref="Advance(int)"/>, <see cref="GetSpan(int)"/>, <see cref="GetMemory(int)"/> must be called
+    /// in a group without calling <see cref="FlushAsync(CancellationToken)"/>. If not, then the call to <see cref="Advance(int)"/>
+    /// will potentially advance the inner pipe rather than the buffer.
+    /// </remarks>
+    private sealed class FlushingBufferedPipeWriter : PipeWriter
+    {
+        private readonly PipeWriter _other;
+
+        private HttpResponseAdapterFeature? _feature;
+        private ArrayBufferWriter<byte>? _buffer;
+
+        public FlushingBufferedPipeWriter(HttpResponseAdapterFeature feature, PipeWriter other)
+        {
+            _feature = feature;
+            _other = other;
+        }
+
+        public override void CancelPendingFlush() => _other.CancelPendingFlush();
+
+        public override void Complete(Exception? exception = null) => _other.Complete(exception);
+
+        public override async ValueTask<FlushResult> FlushAsync(CancellationToken cancellationToken = default)
+        {
+            await FlushExistingDataAsync(cancellationToken);
+
+            return await _other.FlushAsync(cancellationToken);
+        }
+
+        private async ValueTask FlushExistingDataAsync(CancellationToken cancellationToken)
+        {
+            if (_feature is { })
+            {
+                await _feature.DrainStreamAsync(cancellationToken);
+                _feature = null;
+            }
+
+            if (_buffer is { })
+            {
+                await _other.WriteAsync(_buffer.WrittenMemory, cancellationToken);
+                _buffer = null;
+            }
+        }
+
+        public bool IsBuffered => _feature is { };
+
+        public override void Advance(int bytes)
+        {
+            if (_buffer is { })
+            {
+                _buffer.Advance(bytes);
+            }
+            else
+            {
+                _other.Advance(bytes);
+            }
+        }
+
+        public override Memory<byte> GetMemory(int sizeHint = 0)
+        {
+            if (IsBuffered)
+            {
+                return (_buffer ??= new()).GetMemory(sizeHint);
+            }
+            else
+            {
+                return _other.GetMemory(sizeHint);
+            }
+        }
+
+        public override Span<byte> GetSpan(int sizeHint = 0)
+        {
+            if (IsBuffered)
+            {
+                return (_buffer ??= new()).GetSpan(sizeHint);
+            }
+            else
+            {
+                return _other.GetSpan(sizeHint);
+            }
+        }
+    }
 }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/Features/IHttpResponseBufferingFeature.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/Features/IHttpResponseBufferingFeature.cs
@@ -16,12 +16,14 @@ namespace Microsoft.AspNetCore.SystemWebAdapters.Features;
 [Experimental(Constants.ExperimentalFeatures.DiagnosticId)]
 public interface IHttpResponseBufferingFeature
 {
-    void EnableBuffering(int memoryThreshold, long? bufferLimit);
+    void EnableBuffering(int? memoryThreshold = default, long? bufferLimit = default);
 
     ValueTask FlushAsync();
 
     [AllowNull]
     Stream Filter { get; set; }
+
+    void DisableBuffering();
 
     bool IsEnabled { get; }
 }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
@@ -534,7 +534,7 @@ namespace System.Web
     public partial class HttpResponseBase
     {
         public HttpResponseBase() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
-        public virtual bool BufferOutput { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public virtual bool BufferOutput { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual System.Web.HttpCachePolicy Cache { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual string Charset { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual System.Text.Encoding ContentEncoding { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
@@ -578,7 +578,7 @@ namespace System.Web
     public partial class HttpResponseWrapper : System.Web.HttpResponseBase
     {
         public HttpResponseWrapper(System.Web.HttpResponse response) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
-        public override bool BufferOutput { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public override bool BufferOutput { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override System.Web.HttpCachePolicy Cache { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override string Charset { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override System.Text.Encoding ContentEncoding { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
@@ -556,7 +556,7 @@ namespace System.Web
     {
         public HttpResponseBase() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public virtual bool BufferOutput { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
-        public virtual System.Web.HttpCachePolicy Cache { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public virtual System.Web.HttpCachePolicyBase Cache { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual string Charset { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual System.Text.Encoding ContentEncoding { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public virtual string ContentType { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
@@ -600,7 +600,7 @@ namespace System.Web
     {
         public HttpResponseWrapper(System.Web.HttpResponse response) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public override bool BufferOutput { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
-        public override System.Web.HttpCachePolicy Cache { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public override System.Web.HttpCachePolicyBase Cache { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override string Charset { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override System.Text.Encoding ContentEncoding { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public override string ContentType { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
@@ -490,7 +490,7 @@ namespace System.Web
     public partial class HttpResponse
     {
         internal HttpResponse() { }
-        public bool BufferOutput { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
+        public bool BufferOutput { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public System.Web.HttpCachePolicy Cache { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public string Charset { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }
         public System.Text.Encoding ContentEncoding { get { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} set { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");} }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponse.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponse.cs
@@ -75,7 +75,23 @@ namespace System.Web
             set => Response.HttpContext.Features.GetRequired<IStatusCodePagesFeature>().Enabled = value;
         }
 
-        public bool BufferOutput => Response.HttpContext.Features.GetRequired<IHttpResponseBufferingFeature>().IsEnabled;
+        public bool BufferOutput
+        {
+            get => Response.HttpContext.Features.GetRequired<IHttpResponseBufferingFeature>().IsEnabled;
+            set
+            {
+                var feature = Response.HttpContext.Features.GetRequired<IHttpResponseBufferingFeature>();
+
+                if (value)
+                {
+                    feature.EnableBuffering();
+                }
+                else
+                {
+                    feature.DisableBuffering();
+                }
+            }
+        }
 
         public Stream OutputStream => Response.Body;
 

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponseBase.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponseBase.cs
@@ -64,7 +64,11 @@ namespace System.Web
             set => throw new NotImplementedException();
         }
 
-        public virtual bool BufferOutput => throw new NotImplementedException();
+        public virtual bool BufferOutput
+        {
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
+        }
 
         public virtual Stream OutputStream => throw new NotImplementedException();
 

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponseWrapper.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpResponseWrapper.cs
@@ -59,7 +59,11 @@ namespace System.Web
             set => _response.Output = value;
         }
 
-        public override bool BufferOutput => _response.BufferOutput;
+        public override bool BufferOutput
+        {
+            get => _response.BufferOutput;
+            set => _response.BufferOutput = value;
+        }
 
         public override Stream OutputStream => _response.OutputStream;
 


### PR DESCRIPTION
If buffering is turned on (either because using HttpModules or the endpoint metadata), it was broken to call `ctx.Features.GetRequired<IHttpResponseBodyFeature>().DisableBuffering()`. This fixes that.

Fixes #508
