### PR TITLE
Add support for HttpApplication.PreSendRequestContent

### DIFF
--- a/samples/Modules/ModulesLibrary/BaseModule.cs
+++ b/samples/Modules/ModulesLibrary/BaseModule.cs
@@ -12,7 +12,7 @@ namespace ModulesLibrary
         {
         }
 
-        public void Init(HttpApplication application)
+        public virtual void Init(HttpApplication application)
         {
             if (application is null)
             {
@@ -38,6 +38,7 @@ namespace ModulesLibrary
             application.PostUpdateRequestCache += (s, e) => WriteDetails(s, nameof(application.PostUpdateRequestCache));
             application.PreRequestHandlerExecute += (s, e) => WriteDetails(s, nameof(application.PreRequestHandlerExecute));
             application.PreSendRequestHeaders += (s, e) => WriteDetails(s, nameof(application.PreSendRequestHeaders));
+            application.PreSendRequestContent += (s, e) => WriteDetails(s, nameof(application.PreSendRequestContent));
             application.ReleaseRequestState += (s, e) => WriteDetails(s, nameof(application.ReleaseRequestState));
             application.ResolveRequestCache += (s, e) => WriteDetails(s, nameof(application.ResolveRequestCache));
             application.UpdateRequestCache += (s, e) => WriteDetails(s, nameof(application.UpdateRequestCache));

--- a/samples/Modules/ModulesLibrary/EventsModule.cs
+++ b/samples/Modules/ModulesLibrary/EventsModule.cs
@@ -10,6 +10,16 @@ namespace ModulesLibrary
         public const string Complete = "complete";
         public const string Throw = "throw";
 
+        public override void Init(HttpApplication application)
+        {
+            if (application is { })
+            {
+                application.BeginRequest += (s, o) => ((HttpApplication)s!).Context.Response.ContentType = "text/plain";
+
+                base.Init(application);
+            }
+        }
+
         protected override void InvokeEvent(HttpContext context, string name)
         {
             if (context is null)
@@ -17,16 +27,18 @@ namespace ModulesLibrary
                 throw new ArgumentNullException(nameof(context));
             }
 
-            if (context.CurrentNotification == RequestNotification.BeginRequest)
-            {
-                context.Response.ContentType = "text/plain";
-            }
+            var action = context.Request.QueryString["action"];
 
-            context.Response.Output.WriteLine(name);
+            var writeOutputBefore = action != Throw;
+
+            if (writeOutputBefore)
+            {
+                context.Response.Output.WriteLine(name);
+            }
 
             if (string.Equals(name, context.Request.QueryString["notification"], StringComparison.OrdinalIgnoreCase))
             {
-                switch (context.Request.QueryString["action"])
+                switch (action)
                 {
                     case End:
                         context.Response.End();
@@ -37,6 +49,11 @@ namespace ModulesLibrary
                     case Throw:
                         throw new InvalidOperationException();
                 }
+            }
+
+            if (!writeOutputBefore)
+            {
+                context.Response.Output.WriteLine(name);
             }
         }
     }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Features/HttpApplicationPreSendEventsResponseBodyFeature.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Features/HttpApplicationPreSendEventsResponseBodyFeature.cs
@@ -1,0 +1,98 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Buffers;
+using System.IO;
+using System.IO.Pipelines;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+
+namespace Microsoft.AspNetCore.SystemWebAdapters.Features;
+
+/// <summary>
+/// Used to intercept calls to Flush so we can raise <see cref="ApplicationEvent.PreSendRequestHeaders"/> and <see cref="ApplicationEvent.PreSendRequestContent"/> events
+/// </summary>
+internal sealed class HttpApplicationPreSendEventsResponseBodyFeature : PipeWriter, IHttpResponseBodyFeature
+{
+    private State _state;
+    private int _byteCount;
+
+    private readonly PipeWriter _pipe;
+    private readonly IHttpResponseBodyFeature _other;
+    private readonly HttpContextCore _context;
+
+    private enum State
+    {
+        NotStarted,
+        RaisingPreHeader,
+        ReadyForContent,
+        RaisingPreContent,
+    }
+
+    public HttpApplicationPreSendEventsResponseBodyFeature(HttpContextCore context, IHttpResponseBodyFeature other)
+    {
+        _other = other;
+        _pipe = _other.Writer;
+        _context = context;
+    }
+
+    public Stream Stream => Writer.AsStream();
+
+    public PipeWriter Writer => this;
+
+    Task IHttpResponseBodyFeature.CompleteAsync() => _other.CompleteAsync();
+
+    void IHttpResponseBodyFeature.DisableBuffering() => _other.DisableBuffering();
+
+    public Task SendFileAsync(string path, long offset, long? count, CancellationToken cancellationToken = default)
+        => SendFileFallback.SendFileAsync(Stream, path, offset, count, cancellationToken);
+
+    public Task StartAsync(CancellationToken cancellationToken = default) => _other.StartAsync(cancellationToken);
+
+    public override void Advance(int bytes)
+    {
+        // Don't track additional bytes written when events are being raised or we end up with some recursion
+        if (_state is not State.RaisingPreContent or State.RaisingPreHeader)
+        {
+            _byteCount += bytes;
+        }
+
+        _pipe.Advance(bytes);
+    }
+
+    public override void CancelPendingFlush() => _pipe.CancelPendingFlush();
+
+    public override void Complete(Exception? exception = null) => _pipe.Complete(exception);
+
+    public override async ValueTask<FlushResult> FlushAsync(CancellationToken cancellationToken = default)
+    {
+        // Only need to raise events if data will be flushed and the feature is available
+        if (_byteCount > 0 && _context.Features.Get<IHttpApplicationFeature>() is { } httpApplication)
+        {
+            _byteCount = 0;
+
+            if (_state is State.NotStarted)
+            {
+                _state = State.RaisingPreHeader;
+                await _context.Features.GetRequired<IHttpApplicationFeature>().RaiseEventAsync(ApplicationEvent.PreSendRequestHeaders);
+                _state = State.ReadyForContent;
+            }
+
+            if (_state is State.ReadyForContent)
+            {
+                _state = State.RaisingPreContent;
+                await httpApplication.RaiseEventAsync(ApplicationEvent.PreSendRequestContent);
+                _state = State.ReadyForContent;
+            }
+        }
+
+        return await _pipe.FlushAsync(cancellationToken);
+    }
+
+    public override Memory<byte> GetMemory(int sizeHint = 0) => _pipe.GetMemory(sizeHint);
+
+    public override Span<byte> GetSpan(int sizeHint = 0) => _pipe.GetSpan(sizeHint);
+}

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpApplication/HttpApplicationOptions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpApplication/HttpApplicationOptions.cs
@@ -6,7 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Web;
-
+using Microsoft.AspNetCore.SystemWebAdapters.Features;
 using static System.FormattableString;
 
 namespace Microsoft.AspNetCore.SystemWebAdapters;
@@ -47,6 +47,11 @@ public class HttpApplicationOptions
     }
 
     public IDictionary<string, Type> Modules => ModuleCollection;
+
+    /// <summary>
+    /// Gets or sets whether <see cref="HttpApplication.PreSendRequestHeaders"/> and <see cref="HttpApplication.PreSendRequestContent"/> is supported
+    /// </summary>
+    public bool ArePreSendEventsEnabled { get; set; }
 
     /// <summary>
     /// Gets or sets the number of <see cref="HttpApplication"/> retained for reuse. In order to support modules and applications that may contain state,

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpApplication/RegisterHttpApplicationPreSendEventsMiddleware.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpApplication/RegisterHttpApplicationPreSendEventsMiddleware.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.SystemWebAdapters.Features;
+
+namespace Microsoft.AspNetCore.SystemWebAdapters;
+
+internal sealed class RegisterHttpApplicationPreSendEventsMiddleware(RequestDelegate next)
+{
+    public async Task InvokeAsync(HttpContextCore context)
+    {
+        var previous = context.Features.GetRequired<IHttpResponseBodyFeature>();
+        var feature = new HttpApplicationPreSendEventsResponseBodyFeature(context, previous);
+
+        context.Features.Set<IHttpResponseBodyFeature>(feature);
+
+        await next(context);
+
+        context.Features.Set<IHttpResponseBodyFeature>(previous);
+    }
+}

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/SystemWebAdaptersExtensions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/SystemWebAdaptersExtensions.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.SystemWebAdapters;
 using Microsoft.AspNetCore.SystemWebAdapters.Features;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -146,7 +147,7 @@ public static class SystemWebAdaptersExtensions
             {
                 builder.UseMiddleware<SetHttpContextTimestampMiddleware>();
 
-                if (builder.AreHttpApplicationEventsRequired())
+                if (builder.AreHttpApplicationEventsRequired() && builder.ApplicationServices.GetRequiredService<IOptions<HttpApplicationOptions>>().Value.ArePreSendEventsEnabled)
                 {
                     // Must be registered first in order to intercept each flush to the client
                     builder.UseMiddleware<RegisterHttpApplicationPreSendEventsMiddleware>();

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/SystemWebAdaptersExtensions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/SystemWebAdaptersExtensions.cs
@@ -145,6 +145,13 @@ public static class SystemWebAdaptersExtensions
             => builder =>
             {
                 builder.UseMiddleware<SetHttpContextTimestampMiddleware>();
+
+                if (builder.AreHttpApplicationEventsRequired())
+                {
+                    // Must be registered first in order to intercept each flush to the client
+                    builder.UseMiddleware<RegisterHttpApplicationPreSendEventsMiddleware>();
+                }
+
                 builder.UseMiddleware<RegisterAdapterFeaturesMiddleware>();
                 builder.UseMiddleware<SessionStateMiddleware>();
 

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/Features/ApplicationEvent.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Adapters/Features/ApplicationEvent.cs
@@ -57,6 +57,8 @@ public enum ApplicationEvent
 
     PreSendRequestHeaders,
 
+    PreSendRequestContent,
+
     Error,
 
     SessionStart,

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
@@ -52,6 +52,7 @@ namespace System.Web
         public event System.EventHandler PostResolveRequestCache { add { } remove { } }
         public event System.EventHandler PostUpdateRequestCache { add { } remove { } }
         public event System.EventHandler PreRequestHandlerExecute { add { } remove { } }
+        public event System.EventHandler PreSendRequestContent { add { } remove { } }
         public event System.EventHandler PreSendRequestHeaders { add { } remove { } }
         public event System.EventHandler ReleaseRequestState { add { } remove { } }
         public event System.EventHandler ResolveRequestCache { add { } remove { } }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/HttpApplication.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/HttpApplication.cs
@@ -251,6 +251,12 @@ public class HttpApplication : IDisposable
         remove => RemoveEvent(value);
     }
 
+    public event EventHandler? PreSendRequestContent
+    {
+        add => AddEvent(value);
+        remove => RemoveEvent(value);
+    }
+
     private void AddEvent(EventHandler? handler, [CallerMemberName] string? name = null)
     {
         if (handler is null)

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/Modules/BufferedModuleTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/Modules/BufferedModuleTests.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests;
+
+public class BufferedModuleTests : ModuleTests
+{
+    public BufferedModuleTests()
+        : base(true)
+    {
+    }
+}

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/Modules/ModuleTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/Modules/ModuleTests.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using System.Web;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.SystemWebAdapters.Features;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
@@ -20,7 +19,7 @@ using Xunit;
 namespace Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests;
 
 [Collection(nameof(SelfHostedTests))]
-public class ModuleTests
+public abstract class ModuleTests(bool isBuffered)
 {
     private static readonly ImmutableArray<ApplicationEvent> BeforeHandlerEvents =
     [
@@ -56,7 +55,14 @@ public class ModuleTests
 
     public static IEnumerable<object[]> GetAllEvents()
     {
-        IEnumerable<ApplicationEvent> all = [.. BeforeHandlerEvents, .. AfterHandlerEvents, .. EndEvents, ApplicationEvent.PreSendRequestHeaders];
+        IEnumerable<ApplicationEvent> all =
+        [
+            .. BeforeHandlerEvents,
+            .. AfterHandlerEvents,
+            .. EndEvents,
+            ApplicationEvent.PreSendRequestHeaders,
+            ApplicationEvent.PreSendRequestContent
+        ];
 
         var modes = Enum.GetValues<RegisterMode>();
 
@@ -74,7 +80,7 @@ public class ModuleTests
     public async Task EndModuleEarly(ApplicationEvent notification, RegisterMode mode)
     {
         var expected = GetNotificationsUpTo(notification);
-        var result = await RunAsync(ModuleTestModule.End, notification, mode);
+        var result = await RunAsync(EventsModule.End, notification, mode);
 
         Assert.Equal(expected, result);
     }
@@ -84,7 +90,7 @@ public class ModuleTests
     public async Task CompleteModuleEarly(ApplicationEvent notification, RegisterMode mode)
     {
         var expected = GetNotificationsUpTo(notification);
-        var result = await RunAsync(ModuleTestModule.Complete, notification, mode);
+        var result = await RunAsync(EventsModule.Complete, notification, mode);
 
         Assert.Equal(expected, result);
     }
@@ -94,13 +100,13 @@ public class ModuleTests
     public async Task ModulesThrow(ApplicationEvent notification, RegisterMode mode)
     {
         var expected = GetExpected(notification).ToList();
-        var result = await RunAsync(ModuleTestModule.Throw, notification, mode);
+        var result = await RunAsync(EventsModule.Throw, notification, mode);
 
         Assert.Equal(expected, result);
 
-        static IEnumerable<ApplicationEvent> GetExpected(ApplicationEvent notification)
+        IEnumerable<ApplicationEvent> GetExpected(ApplicationEvent notification)
         {
-            foreach (var item in GetNotificationsUpTo(notification))
+            foreach (var item in GetNotificationsUpTo(notification, isThrowing: true))
             {
                 yield return item;
 
@@ -112,31 +118,97 @@ public class ModuleTests
         }
     }
 
-    private static IEnumerable<ApplicationEvent> GetNotificationsUpTo(ApplicationEvent notification)
+    private IEnumerable<ApplicationEvent> GetNotificationsUpTo(ApplicationEvent notification, bool isThrowing = false)
     {
-        IEnumerable<ApplicationEvent> initial = [.. BeforeHandlerEvents, .. AfterHandlerEvents];
+        return isBuffered
+                ? GetExpectedBufferedNotificationsUntilAction(notification, isThrowing)
+                : GetExpectedUnbufferedNotificationsUntilAction(notification, isThrowing);
 
-        foreach (var n in initial)
+        // When the stream is buffered, we expect the notifications to be grouped mostly together and the PreSend* events are sent at the end
+        static IEnumerable<ApplicationEvent> GetExpectedBufferedNotificationsUntilAction(ApplicationEvent notification, bool isThrowing = false)
         {
-            yield return n;
+            IEnumerable<ApplicationEvent> initial = [.. BeforeHandlerEvents, .. AfterHandlerEvents];
 
-            if (n == notification)
+            foreach (var n in initial)
             {
-                break;
+                yield return n;
+
+                if (n == notification)
+                {
+                    break;
+                }
+            }
+
+            foreach (var n in EndEvents)
+            {
+                yield return n;
+            }
+
+            yield return ApplicationEvent.PreSendRequestHeaders;
+
+            var expectsFinalPreSendRequestContent = !(isThrowing && notification is ApplicationEvent.PreSendRequestHeaders);
+
+            if (expectsFinalPreSendRequestContent)
+            {
+                yield return ApplicationEvent.PreSendRequestContent;
             }
         }
 
-        foreach (var n in EndEvents)
+        // When the stream is unbuffered, the PreSend* events will occur during each event because we we cause data to be flushed for the test
+        static IEnumerable<ApplicationEvent> GetExpectedUnbufferedNotificationsUntilAction(ApplicationEvent notification, bool isThrowing)
         {
-            yield return n;
-        }
+            var remaining = EndEvents;
+            var bufferedEvents = GetExpectedBufferedNotificationsUntilAction(notification, isThrowing)
+                .Where(e => e is not ApplicationEvent.PreSendRequestHeaders)
+                .Where(e => e is not ApplicationEvent.PreSendRequestContent);
+            var hasSentPreSendHeader = false;
 
-        yield return ApplicationEvent.PreSendRequestHeaders;
+            foreach (var appEvent in bufferedEvents)
+            {
+                yield return appEvent;
+
+                remaining = remaining.Remove(appEvent);
+
+                if (!hasSentPreSendHeader)
+                {
+                    hasSentPreSendHeader = true;
+                    yield return ApplicationEvent.PreSendRequestHeaders;
+
+                    if (notification is ApplicationEvent.PreSendRequestHeaders)
+                    {
+                        break;
+                    }
+                }
+
+                if (notification != ApplicationEvent.PreSendRequestHeaders || !isThrowing)
+                {
+                    yield return ApplicationEvent.PreSendRequestContent;
+                }
+
+                if (notification is ApplicationEvent.PreSendRequestContent)
+                {
+                    break;
+                }
+            }
+
+            foreach (var r in remaining)
+            {
+                yield return r;
+            }
+
+            var expectsFinalPreSendRequestContent = !(isThrowing && notification is ApplicationEvent.PreSendRequestContent or ApplicationEvent.PreSendRequestHeaders);
+
+            if (!remaining.IsEmpty && expectsFinalPreSendRequestContent)
+            {
+                yield return ApplicationEvent.PreSendRequestContent;
+            }
+        }
     }
 
-    private static async Task<List<ApplicationEvent>> RunAsync(string action, ApplicationEvent @event, RegisterMode mode)
+    private async Task<List<ApplicationEvent>> RunAsync(string action, ApplicationEvent @event, RegisterMode mode)
     {
         var notifier = new NotificationCollection();
+        var module = isBuffered ? typeof(BufferedTestModule) : typeof(NotBufferedTestModule);
 
         using var host = await new HostBuilder()
             .ConfigureWebHost(webBuilder =>
@@ -155,7 +227,7 @@ public class ModuleTests
                             {
                                 if (mode == RegisterMode.Options)
                                 {
-                                    options.RegisterModule<ModuleTestModule>();
+                                    options.RegisterModule(module);
                                 }
                             });
 
@@ -164,13 +236,13 @@ public class ModuleTests
                     {
                         if (mode == RegisterMode.RegisterModule)
                         {
-                            HttpApplication.RegisterModule(typeof(ModuleTestModule));
+                            HttpApplication.RegisterModule(module);
                         }
                         else if (mode == RegisterMode.RegisterModuleOnStartup)
                         {
                             app.ApplicationServices.GetRequiredService<IHostApplicationLifetime>().ApplicationStarted.Register(() =>
                             {
-                                HttpApplication.RegisterModule(typeof(ModuleTestModule));
+                                HttpApplication.RegisterModule(module);
                             });
                         }
 
@@ -199,76 +271,16 @@ public class ModuleTests
         return notifier;
     }
 
-    [Fact]
-    public async Task PreSendEventThrownIfNotBuffering()
-    {
-        // Arrange
-        IEnumerable<ApplicationEvent> expected =
-        [
-            .. BeforeHandlerEvents,
-            ApplicationEvent.PreSendRequestHeaders,
-            .. AfterHandlerEvents,
-            .. EndEvents
-        ];
-
-        var notifier = new NotificationCollection();
-        using var host = await new HostBuilder()
-            .ConfigureWebHost(webBuilder =>
-            {
-                webBuilder
-                    .UseTestServer(options =>
-                    {
-                        options.AllowSynchronousIO = true;
-                    })
-                    .ConfigureServices(services =>
-                    {
-                        services.AddRouting();
-                        services.AddSystemWebAdapters()
-                            .AddHttpApplication(options =>
-                            {
-                                options.RegisterModule<ModulePreSendHeaders>();
-                            });
-
-                    })
-                    .Configure(app =>
-                    {
-                        app.Use((ctx, next) =>
-                        {
-                            ctx.Features.Set(notifier);
-                            return next(ctx);
-                        });
-                        app.UseRouting();
-
-                        app.UseSystemWebAdapters();
-
-                        app.UseEndpoints(endpoints =>
-                        {
-                            endpoints.Map("/", (HttpContextCore ctx) =>
-                            {
-                                ctx.Features.GetRequired<IHttpResponseBodyFeature>().DisableBuffering();
-
-                                var systemWeb = ctx.AsSystemWeb();
-                                systemWeb.Response.Write(systemWeb.CurrentNotification);
-                                systemWeb.Response.Write(" ");
-                                systemWeb.Response.Output.Flush();
-                                systemWeb.Response.Write(systemWeb.CurrentNotification);
-                                systemWeb.Response.Output.Flush();
-                            });
-                        });
-                    });
-            })
-            .StartAsync();
-
-        // Act
-        var result = await host.GetTestClient().GetStringAsync(new Uri("/", UriKind.Relative));
-
-        // Assert
-        Assert.Equal(expected, notifier);
-        Assert.Equal(result, $"{ApplicationEvent.ExecuteRequestHandler} {ApplicationEvent.ExecuteRequestHandler}");
-    }
-
     private sealed class NotificationCollection : List<ApplicationEvent>
     {
+        public new void Add(ApplicationEvent appEvent)
+        {
+            // Prevent duplicate PreSendRequestContent since we can't really control when the Flush is called so we just want to track that at least one occurs with the test
+            if (appEvent != ApplicationEvent.PreSendRequestContent || this[^1] != ApplicationEvent.PreSendRequestContent)
+            {
+                base.Add(appEvent);
+            }
+        }
     }
 
     private sealed class ModuleTestStartup : IStartupFilter
@@ -293,7 +305,7 @@ public class ModuleTests
                     {
                         await next(ctx);
                     }
-                    catch (InvalidOperationException) when (_action == ModuleTestModule.Throw)
+                    catch (InvalidOperationException) when (_action == EventsModule.Throw)
                     {
                     }
                 });
@@ -302,15 +314,16 @@ public class ModuleTests
             };
     }
 
-    private sealed class ModulePreSendHeaders : BaseModule
+    private sealed class NotBufferedTestModule : BufferedTestModule
     {
-        protected override void InvokeEvent(HttpContext context, string name)
+        public override void Init(HttpApplication application)
         {
-            context.AsAspNetCore().Features.GetRequired<NotificationCollection>().Add(Enum.Parse<ApplicationEvent>(name, ignoreCase: false));
+            application.BeginRequest += (s, o) => ((HttpApplication)s!).Context.Response.BufferOutput = false;
+            base.Init(application);
         }
     }
 
-    private sealed class ModuleTestModule : EventsModule
+    private class BufferedTestModule : EventsModule
     {
         protected override void InvokeEvent(HttpContext context, string name)
         {

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/Modules/ModuleTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/Modules/ModuleTests.cs
@@ -229,6 +229,8 @@ public abstract class ModuleTests(bool isBuffered)
                                 {
                                     options.RegisterModule(module);
                                 }
+
+                                options.ArePreSendEventsEnabled = true;
                             });
 
                     })

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/Modules/NotBufferedModuleTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/Modules/NotBufferedModuleTests.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests;
+
+public class NotBufferedModuleTests : ModuleTests
+{
+    public NotBufferedModuleTests()
+        : base(false)
+    {
+    }
+}


### PR DESCRIPTION
In order to support this event, we need to hook into the point at which content is flushed to the client. To achieve this, this change adds the following:

- A new implementation of IHttpResponseBodyFeature that gets added early when modules are registered that will intercept calls to FlushAsync
- Moves the PreSendRequestHeaders to the same interception point
- Reworks tests to run all the module tests for both buffered and non-buffered streams