### PR TITLE
Make IRemoteAppAuthenticationService public for use in testing

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Authentication/IRemoteAppAuthenticationService.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Authentication/IRemoteAppAuthenticationService.cs
@@ -11,20 +11,15 @@ namespace Microsoft.AspNetCore.SystemWebAdapters.Authentication
     /// <summary>
     /// A service for authenticating an HTTP request with a remote service.
     /// </summary>
-    internal interface IRemoteAppAuthenticationService
+    public interface IRemoteAppAuthenticationService
     {
-        /// <summary>
-        /// Initializes the remote authentication service for the given scheme.
-        /// </summary>
-        /// <param name="scheme">The scheme whose configuration the remote authentication service should use for authenticating requests.</param>
-        Task InitializeAsync(AuthenticationScheme scheme);
-
         /// <summary>
         /// Attempts to authenticate a user who made a given HTTP request by forwarding portions of the request to a remote service.
         /// </summary>
-        /// <param name="originalRequest">The request originally made by the user to be authenticated.</param>
+        /// <param name="scheme">The scheme being used for authentication.</param>
+        /// <param name="request">The request that is to be authenticated.</param>
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns></returns>
-        Task<RemoteAppAuthenticationResult> AuthenticateAsync(HttpRequest originalRequest, CancellationToken cancellationToken);
+        Task<RemoteAppAuthenticationResult> AuthenticateAsync(AuthenticationScheme scheme, HttpRequest request, CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Authentication/RemoteAppAuthenticationAuthHandler.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Authentication/RemoteAppAuthenticationAuthHandler.cs
@@ -42,14 +42,12 @@ internal partial class RemoteAppAuthenticationAuthHandler : AuthenticationHandle
         _resultProcessors = resultProcessors;
     }
 
-    protected override Task InitializeHandlerAsync() => _authService.InitializeAsync(Scheme);
-
     private async Task<RemoteAppAuthenticationResult> GetRemoteAppAuthenticationResultAsync()
     {
         if (_remoteAppAuthResult is null)
         {
             // Retrieve the remote authentication result and apply any processors
-            _remoteAppAuthResult = await _authService.AuthenticateAsync(Context.Request, CancellationToken.None);
+            _remoteAppAuthResult = await _authService.AuthenticateAsync(Scheme, Context.Request, Context.RequestAborted);
             foreach (var processor in _resultProcessors)
             {
                 await processor.ProcessAsync(_remoteAppAuthResult, Context);

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Authentication/RemoteAppAuthenticationExtensions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Authentication/RemoteAppAuthenticationExtensions.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.SystemWebAdapters;
 using Microsoft.AspNetCore.SystemWebAdapters.Authentication;
 using Microsoft.AspNetCore.SystemWebAdapters.Authentication.ResultProcessors;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -52,9 +53,9 @@ public static class RemoteAppAuthenticationExtensions
     {
         ArgumentNullException.ThrowIfNull(authenticationBuilder);
 
-        authenticationBuilder.Services.AddScoped<IRemoteAppAuthenticationResultProcessor, RedirectUrlProcessor>();
-        authenticationBuilder.Services.AddSingleton<IAuthenticationResultFactory, RemoteAppAuthenticationResultFactory>();
-        authenticationBuilder.Services.AddTransient<IRemoteAppAuthenticationService, RemoteAppAuthenticationService>();
+        authenticationBuilder.Services.TryAddScoped<IRemoteAppAuthenticationResultProcessor, RedirectUrlProcessor>();
+        authenticationBuilder.Services.TryAddSingleton<IAuthenticationResultFactory, RemoteAppAuthenticationResultFactory>();
+        authenticationBuilder.Services.TryAddSingleton<IRemoteAppAuthenticationService, RemoteAppAuthenticationService>();
         authenticationBuilder.Services.AddOptions<RemoteAppAuthenticationClientOptions>(scheme)
             .Configure(configureOptions ?? (_ => { }))
             .ValidateDataAnnotations();

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Authentication/RemoteAppAuthenticationService.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Authentication/RemoteAppAuthenticationService.cs
@@ -25,70 +25,51 @@ internal partial class RemoteAppAuthenticationService : IRemoteAppAuthentication
     private readonly HttpClient _client;
     private readonly IAuthenticationResultFactory _resultFactory;
     private readonly ILogger<RemoteAppAuthenticationService> _logger;
-    private readonly IOptionsSnapshot<RemoteAppAuthenticationClientOptions> _authOptionsSnapshot;
-
-    private RemoteAppAuthenticationClientOptions? _options;
+    private readonly IOptionsMonitor<RemoteAppAuthenticationClientOptions> _authOptionsMonitor;
 
     public RemoteAppAuthenticationService(
         IAuthenticationResultFactory resultFactory,
-        IOptionsSnapshot<RemoteAppAuthenticationClientOptions> authOptions,
+        IOptionsMonitor<RemoteAppAuthenticationClientOptions> authOptions,
         IOptions<RemoteAppClientOptions> remoteAppOptions,
         ILogger<RemoteAppAuthenticationService> logger)
     {
         _resultFactory = resultFactory ?? throw new ArgumentNullException(nameof(resultFactory));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _authOptionsSnapshot = authOptions ?? throw new ArgumentNullException(nameof(authOptions));
+        _authOptionsMonitor = authOptions ?? throw new ArgumentNullException(nameof(authOptions));
         _client = remoteAppOptions?.Value.BackchannelClient ?? throw new ArgumentNullException(nameof(remoteAppOptions));
-    }
-
-    /// <summary>
-    /// Initialize the remote authentication service for a given authentication scheme.
-    /// </summary>
-    /// <param name="scheme">The scheme whose configuration should be used to authenticate.</param>
-    public Task InitializeAsync(AuthenticationScheme scheme)
-    {
-        // Finish initializing the http client here since the scheme won't be known
-        // until the owning authentication handler is initialized.
-        _options = _authOptionsSnapshot.Get(scheme.Name);
-
-        return Task.CompletedTask;
     }
 
     /// <summary>
     /// Authenticate the user of a request by making a request to a remote app using configured
     /// headers and/or cookies from the current request.
     /// </summary>
-    /// <param name="originalRequest">The HTTP request to authenticate.</param>
+    /// <param name="request">The HTTP request to authenticate.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>
-    /// An authenticaiton result including the claims principal of the authenticated user (if any)
+    /// An authentication result including the claims principal of the authenticated user (if any)
     /// and a status code and headers to include in the response to the request in case the user could not be authenticated.
     /// </returns>
     /// <exception cref="InvalidOperationException">
     /// An invalid operation exception is thrown if
     /// AuthenticateAsync is called without calling Initialize.
     /// </exception>
-    public async Task<RemoteAppAuthenticationResult> AuthenticateAsync(HttpRequest originalRequest, CancellationToken cancellationToken)
+    public async Task<RemoteAppAuthenticationResult> AuthenticateAsync(AuthenticationScheme scheme, HttpRequest request, CancellationToken cancellationToken)
     {
-        if (_options is null)
-        {
-            LogHandlerNotInitialized();
-            throw new InvalidOperationException("Remote authentication handler must be initialized before authenticating");
-        }
+        var options = _authOptionsMonitor.Get(scheme.Name);
 
         // Create a new HTTP request, but propagate along configured headers or cookies
         // that may matter for authentication. Also include the original request path as
         // as a query parameter so that the ASP.NET app can redirect back to it if an
         // authentication provider attempts to redirect back to the authenticate URL.
-        var url = $"{_options.Path.Relative}?{AuthenticationConstants.OriginalUrlQueryParamName}={WebUtility.UrlEncode(originalRequest.GetEncodedPathAndQuery())}";
+        var url = $"{options.Path.Relative}?{AuthenticationConstants.OriginalUrlQueryParamName}={WebUtility.UrlEncode(request.GetEncodedPathAndQuery())}";
         using var authRequest = new HttpRequestMessage(HttpMethod.Get, url);
-        AddHeaders(_options.RequestHeadersToForward, originalRequest, authRequest);
+        AddHeaders(options.RequestHeadersToForward, request, authRequest);
 
         // Get the response from the remote app and convert the response into a remote authentication result
         using var response = await _client.SendAsync(authRequest, cancellationToken);
         LogAuthenticationResponse(response.StatusCode);
 
-        return await _resultFactory.CreateRemoteAppAuthenticationResultAsync(response, _options);
+        return await _resultFactory.CreateRemoteAppAuthenticationResultAsync(response, options);
     }
 
     // Add configured headers to the request, or all headers if none in particular are specified
@@ -134,9 +115,6 @@ internal partial class RemoteAppAuthenticationService : IRemoteAppAuthentication
             authRequest.Headers.Add(headerName, originalHeaders);
         }
     }
-
-    [LoggerMessage(EventId = 0, Level = LogLevel.Error, Message = "Failed to authenticate using the remote app due to invalid or missing API key")]
-    private partial void LogHandlerNotInitialized();
 
     [LoggerMessage(EventId = 1, Level = LogLevel.Debug, Message = "Received remote authentication response with status code {StatusCode}")]
     private partial void LogAuthenticationResponse(HttpStatusCode statusCode);

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Authentication/RemoteAppAuthenticationService.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Authentication/RemoteAppAuthenticationService.cs
@@ -43,6 +43,7 @@ internal partial class RemoteAppAuthenticationService : IRemoteAppAuthentication
     /// Authenticate the user of a request by making a request to a remote app using configured
     /// headers and/or cookies from the current request.
     /// </summary>
+    /// <param name="scheme">The authentication scheme currently in use.</param>
     /// <param name="request">The HTTP request to authenticate.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>


### PR DESCRIPTION
This change also passes the AuthenticationScheme into the AuthenticateAsync method so that the implementations of this interface can be a singleton.