### PR TITLE
Disable framework hosted compiler for now

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,6 +12,13 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <LangVersion>12</LangVersion>
+
+    <!--
+      Workaround for now as things are broken in VS without this. Update when .NET SDK 9 Preview 7 or later is added via arcade
+
+      See https://github.com/dotnet/arcade/issues/14311 for details
+    -->
+    <BuildWithNetFrameworkHostedCompiler>false</BuildWithNetFrameworkHostedCompiler>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
The SDK has enabled this by default, but until we're using preview 7, looks like it may have issues
