### PR TITLE
Case insensitive session keys JSON serializer

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters.Abstractions/SessionState/Serialization/JsonSessionSerializerOptions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.Abstractions/SessionState/Serialization/JsonSessionSerializerOptions.cs
@@ -14,7 +14,7 @@ public class JsonSessionSerializerOptions
     /// <summary>
     /// Gets the mapping of known session keys to types
     /// </summary>
-    public IDictionary<string, Type> KnownKeys { get; } = new Dictionary<string, Type>();
+    public IDictionary<string, Type> KnownKeys { get; } = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Registers a session key name to be of type <typeparamref name="T"/>

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/SessionState/Serialization/JsonSessionKeySerializerTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/SessionState/Serialization/JsonSessionKeySerializerTests.cs
@@ -293,6 +293,27 @@ public class JsonSessionKeySerializerTests
         Assert.Equal(primitive, deserialized);
     }
 
+    [Fact]
+    public void CaseInsensitiveSessionKeys()
+    {
+        // Arrange
+        var key = _fixture.Create<string>();
+
+        var options = new JsonSessionSerializerOptions
+        {
+            KnownKeys =
+            {
+                { key, typeof(Type1) },
+            }
+        };
+
+        // Act
+        var result = options.KnownKeys.ContainsKey(key.ToUpperInvariant());
+
+        // Assert
+        Assert.True(result);
+    }
+
     private sealed class Type1
     {
     }


### PR DESCRIPTION
- [x] You've read the [Contributor Guide](../CONTRIBUTING.md) and [Code of Conduct](../CODE-OF-CONDUCT.md).
- [x] You've included unit tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

**PR Title**

Case insensitive session keys for the JSON serializer.

Addresses #536 
