### PR TITLE
Ensure HttpApplication raises SessionStart

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/SessionState/Wrapped/AspNetCoreSessionState.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/SessionState/Wrapped/AspNetCoreSessionState.cs
@@ -26,6 +26,7 @@ internal sealed partial class AspNetCoreSessionState : ISessionState
         _throwOnUnknown = throwOnUnknown;
         _logger = factory.CreateLogger<AspNetCoreSessionState>();
 
+        IsNewSession = !session.Keys.Any();
         IsReadOnly = isReadOnly;
     }
 
@@ -99,7 +100,7 @@ internal sealed partial class AspNetCoreSessionState : ISessionState
 
     public int Timeout { get; set; } = 20;
 
-    public bool IsNewSession => false;
+    public bool IsNewSession { get; }
 
     public int Count => _session.Keys.Count();
 

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/SystemWebAdaptersExtensions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/SystemWebAdaptersExtensions.cs
@@ -96,13 +96,9 @@ public static class SystemWebAdaptersExtensions
                 ApplicationEvent.PostResolveRequestCache,
                 ApplicationEvent.MapRequestHandler,
                 ApplicationEvent.PostMapRequestHandler,
-                ApplicationEvent.AcquireRequestState,
-                ApplicationEvent.PostAcquireRequestState,
             },
             postEvents: new[]
             {
-                ApplicationEvent.ReleaseRequestState,
-                ApplicationEvent.PostReleaseRequestState,
                 ApplicationEvent.UpdateRequestCache,
                 ApplicationEvent.PostUpdateRequestCache,
             });


### PR DESCRIPTION
This fixes two issues that combined do not raise this event:

- A typo sent the event SessionEnd instead of SessionStart
- Wrapped ASP.NET Core session didn't implement the IsNewSession - it was always false. Now we check if there are any keys to determine if it is a new session
