### PR TITLE
Add IHttpHandlerFactory

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
@@ -807,6 +807,11 @@ namespace System.Web
         bool IsReusable { get; }
         void ProcessRequest(System.Web.HttpContext context);
     }
+    public partial interface IHttpHandlerFactory
+    {
+        System.Web.IHttpHandler GetHandler(System.Web.HttpContext context, string requestType, string url, string pathTranslated);
+        void ReleaseHandler(System.Web.IHttpHandler handler);
+    }
     public partial interface IHttpModule
     {
         void Dispose();

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/TypeForwards.Framework.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/TypeForwards.Framework.cs
@@ -61,6 +61,7 @@
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.HttpUnhandledException))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.IHttpAsyncHandler))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.IHttpHandler))]
+[assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.IHttpHandlerFactory))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.IHttpModule))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.ISubscriptionToken))]
 [assembly:System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Web.ReadEntityBodyMode))]

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/IHttpHandlerFactory.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/IHttpHandlerFactory.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Web;
+
+public interface IHttpHandlerFactory
+{
+    [Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1054:URI-like parameters should not be strings", Justification = Constants.ApiFromAspNet)]
+    IHttpHandler GetHandler(HttpContext context, String requestType, String url, String pathTranslated);
+
+    void ReleaseHandler(IHttpHandler handler);
+}


### PR DESCRIPTION
A number of other HTTP handler APIs were ported earlier and this one was
missed. As with the others, this will allow projects to compile, but no
default implementation is provided at the moment.
