### PR TITLE
Moving to Central package management and enabling NuGet auditing

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -9,5 +9,29 @@
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="myget-legacy" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
   </packageSources>
+  <auditSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </auditSources>
+  <packageSourceMapping>
+    <packageSource key="dotnet6">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="dotnet8">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="dotnet-eng">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="dotnet-tools">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="dotnet-public">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="myget-legacy">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
   <disabledPackageSources />
 </configuration>

--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "9.0.100-rc.2.24474.11"
+    "version": "9.0.100"
   },
   "tools": {
-    "dotnet": "9.0.100-rc.2.24474.11",
+    "dotnet": "9.0.100",
     "runtimes": {
       "dotnet": [
         "6.0.4",

--- a/samples/WindowsAuth/WindowsAuth.csproj
+++ b/samples/WindowsAuth/WindowsAuth.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="8.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -13,7 +13,6 @@
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" />
     <PackageVersion Include="System.Runtime.Caching" Version="8.0.0" />
     <PackageVersion Include="System.Security.Principal.Windows" Version="5.0.0" />
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,0 +1,22 @@
+<Project>
+
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Bcl.TimeProvider" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.DotNet.BuildTools.GenAPI" Version="3.0.0-preview4-06015-01" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" />
+    <PackageVersion Include="System.Runtime.Caching" Version="8.0.0" />
+    <PackageVersion Include="System.Security.Principal.Windows" Version="5.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.Abstractions/Microsoft.AspNetCore.SystemWebAdapters.Abstractions.csproj
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.Abstractions/Microsoft.AspNetCore.SystemWebAdapters.Abstractions.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.csproj
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.csproj
@@ -19,7 +19,7 @@
 
   <!-- Provided in box for .NET 8+ -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="Microsoft.Bcl.TimeProvider" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Bcl.TimeProvider" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices.csproj
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices.csproj
@@ -23,11 +23,11 @@
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" />
+    <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.AspNetCore.SystemWebAdapters\Microsoft.AspNetCore.SystemWebAdapters.csproj" />

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/GenerateApis.targets
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/GenerateApis.targets
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="$(__Generate)">
-    <PackageReference Include="Microsoft.DotNet.BuildTools.GenAPI" Version="3.0.0-preview4-06015-01" />
+    <PackageReference Include="Microsoft.DotNet.BuildTools.GenAPI" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Microsoft.AspNetCore.SystemWebAdapters.csproj
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Microsoft.AspNetCore.SystemWebAdapters.csproj
@@ -64,6 +64,7 @@
 
     <Compile Include="IHtmlString.cs" />
     <Compile Include="HtmlString.cs" />
+    <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" />
 
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Microsoft.AspNetCore.SystemWebAdapters.csproj
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Microsoft.AspNetCore.SystemWebAdapters.csproj
@@ -32,14 +32,14 @@
     <Compile Include="IHtmlString.cs" />
     <Compile Include="HtmlString.cs" />
 
-    <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
+    <PackageReference Include="System.Security.Principal.Windows" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
 
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-    <PackageReference Include="System.Runtime.Caching" Version="6.0.0" />
+    <PackageReference Include="System.Runtime.Caching" />
 
     <Using Include="Microsoft.AspNetCore.Http.HttpContext" Alias="HttpContextCore" />
     <Using Include="Microsoft.AspNetCore.Http.HttpResponse" Alias="HttpResponseCore" />
@@ -49,7 +49,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-    <PackageReference Include="System.Runtime.Caching" Version="8.0.0" />
+    <PackageReference Include="System.Runtime.Caching" />
 
     <Using Include="Microsoft.AspNetCore.Http.HttpContext" Alias="HttpContextCore" />
     <Using Include="Microsoft.AspNetCore.Http.HttpResponse" Alias="HttpResponseCore" />
@@ -65,7 +65,7 @@
     <Compile Include="IHtmlString.cs" />
     <Compile Include="HtmlString.cs" />
 
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -1,0 +1,29 @@
+<Project>
+
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+
+<ItemGroup>
+    <PackageVersion Include="AutoFixture" Version="4.15.0" />
+    <PackageVersion Include="Autofac.Extras.Moq" Version="6.0.0" />
+    <PackageVersion Include="Basic.Reference.Assemblies" Version="1.4.5" />
+    <PackageVersion Include="coverlet.collector" Version="3.1.2" />
+    <PackageVersion Include="jQuery" Version="3.7.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="6.0.13" />
+    <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.8.0" />
+    <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.0" />
+    <PackageVersion Include="Microsoft.Playwright.NUnit" Version="1.25.0" />
+    <PackageVersion Include="Moq" Version="4.16.1" />
+    <PackageVersion Include="NUnit" Version="3.13.3" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageVersion Include="NUnit.Analyzers" Version="3.3.0" />
+    <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="6.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
+    <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
+</ItemGroup>
+
+</Project>

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+    <!-- NU1009: The packages Microsoft.NETFramework.ReferenceAssemblies are implicitly referenced. -->
+    <NoWarn>NU1009;$(NoWarn)</NoWarn>
   </PropertyGroup>
 
 <ItemGroup>

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <!-- NU1009: The packages Microsoft.NETFramework.ReferenceAssemblies are implicitly referenced. -->
-    <NoWarn>NU1009;$(NoWarn)</NoWarn>
   </PropertyGroup>
 
 <ItemGroup>

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="jQuery" Version="3.7.1" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="6.0.13" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.8.0" />
-    <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.0" />
+    <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.3" />
     <PackageVersion Include="Microsoft.Playwright.NUnit" Version="1.25.0" />
     <PackageVersion Include="Moq" Version="4.16.1" />
     <PackageVersion Include="NUnit" Version="3.13.3" />

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Apis.Tests/CopyFrameworkAdapters.targets
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Apis.Tests/CopyFrameworkAdapters.targets
@@ -9,7 +9,7 @@
   -->
 
   <ItemGroup>
-    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="6.0.0" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" PrivateAssets="All" Version="1.0.0" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" PrivateAssets="All" />
     <Content Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net472)\build\.NETFramework\v4.7.2\**">
       <Visible>false</Visible>
       <Link>$(FrameworkAdapterDirectory)/%(RecursiveDir)%(Filename)%(Extension)</Link>

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Apis.Tests/CopyFrameworkAdapters.targets
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Apis.Tests/CopyFrameworkAdapters.targets
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" PrivateAssets="All" GeneratePathProperty="true" />
     <Content Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net472)\build\.NETFramework\v4.7.2\**">
       <Visible>false</Visible>
       <Link>$(FrameworkAdapterDirectory)/%(RecursiveDir)%(Filename)%(Extension)</Link>

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Apis.Tests/Microsoft.AspNetCore.SystemWebAdapters.Apis.Tests.csproj
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Apis.Tests/Microsoft.AspNetCore.SystemWebAdapters.Apis.Tests.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac.Extras.Moq" Version="6.0.0" />
-    <PackageReference Include="AutoFixture" Version="4.15.0" />
-    <PackageReference Include="Basic.Reference.Assemblies" Version="1.4.5" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.8.0" />
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Autofac.Extras.Moq" />
+    <PackageReference Include="AutoFixture" />
+    <PackageReference Include="Basic.Reference.Assemblies" />
+    <PackageReference Include="Microsoft.CodeAnalysis" />
+    <PackageReference Include="Moq" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests.csproj
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests.csproj
@@ -3,11 +3,11 @@
     <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac.Extras.Moq" Version="6.0.0" />
-    <PackageReference Include="AutoFixture" Version="4.15.0" />
-    <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.13" />
-    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageReference Include="Autofac.Extras.Moq" />
+    <PackageReference Include="AutoFixture" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" />
+    <PackageReference Include="System.Collections.Immutable" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.SystemWebAdapters.CoreServices\Microsoft.AspNetCore.SystemWebAdapters.CoreServices.csproj" />

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices.Tests/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices.Tests.csproj
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices.Tests/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices.Tests.csproj
@@ -8,9 +8,9 @@
     <Compile Include="..\Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests\SessionState\Serialization\JsonSessionKeySerializerTests.cs" Link="SessionState\JsonSessionKeySerializerTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac.Extras.Moq" Version="6.0.0" />
-    <PackageReference Include="AutoFixture" Version="4.15.0" />
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Autofac.Extras.Moq" />
+    <PackageReference Include="AutoFixture" />
+    <PackageReference Include="Moq" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices\Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices.csproj" />

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.NuGet.Tests/Microsoft.AspNetCore.SystemWebAdapters.NuGet.Tests.csproj
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.NuGet.Tests/Microsoft.AspNetCore.SystemWebAdapters.NuGet.Tests.csproj
@@ -14,7 +14,7 @@
 
   <!-- Used for tests but not directly -->
   <ItemGroup>
-    <PackageReference Include="jQuery" />
+    <PackageReference Include="jQuery" CopyContent="true" />
   </ItemGroup>
 
   <Import Project="$(SolutionRootDirectory)src/Microsoft.AspNetCore.SystemWebAdapters/Build/Microsoft.AspNetCore.SystemWebAdapters.targets" />

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.NuGet.Tests/Microsoft.AspNetCore.SystemWebAdapters.NuGet.Tests.csproj
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.NuGet.Tests/Microsoft.AspNetCore.SystemWebAdapters.NuGet.Tests.csproj
@@ -7,14 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac.Extras.Moq" Version="6.0.0" />
-    <PackageReference Include="AutoFixture" Version="4.15.0" />
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Autofac.Extras.Moq" />
+    <PackageReference Include="AutoFixture" />
+    <PackageReference Include="Moq" />
   </ItemGroup>
 
   <!-- Used for tests but not directly -->
   <ItemGroup>
-    <PackageReference Include="jQuery" Version="3.7.1" CopyContent="true" />
+    <PackageReference Include="jQuery" />
   </ItemGroup>
 
   <Import Project="$(SolutionRootDirectory)src/Microsoft.AspNetCore.SystemWebAdapters/Build/Microsoft.AspNetCore.SystemWebAdapters.targets" />

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/Microsoft.AspNetCore.SystemWebAdapters.Tests.csproj
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.Tests/Microsoft.AspNetCore.SystemWebAdapters.Tests.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac.Extras.Moq" Version="6.0.0" />
-    <PackageReference Include="AutoFixture" Version="4.15.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.8.0" />
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Autofac.Extras.Moq" />
+    <PackageReference Include="AutoFixture" />
+    <PackageReference Include="Microsoft.CodeAnalysis" />
+    <PackageReference Include="Moq" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Samples.MVCApp.Tests/Samples.MVCApp.Tests.csproj
+++ b/test/Samples.MVCApp.Tests/Samples.MVCApp.Tests.csproj
@@ -9,11 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Playwright.NUnit" Version="1.25.0" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Playwright.NUnit" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="NUnit.Analyzers" />
+    <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 
 </Project>

--- a/test/Samples.RemoteAuth.Forms.Tests/Samples.RemoteAuth.Forms.Tests.csproj
+++ b/test/Samples.RemoteAuth.Forms.Tests/Samples.RemoteAuth.Forms.Tests.csproj
@@ -9,11 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Playwright.NUnit" Version="1.25.0" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Playwright.NUnit" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="NUnit.Analyzers" />
+    <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Enabling NuGet auditing to get build errors when one of the packages we depend on is marked as vulnerable.
- Enable Central package management on our `src` and `test` directories (not samples). This will allow us to manage package versions centrally and ensure that all projects use the same version of a package, as well as be able to transitive pin when required due to transitive dependencies marked as vulnerable.
- Bump the SDK we use to build to the now released 9.0.100


cc: @twsouthwick 