### PR TITLE
Copy the keys from framework session state

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices/SessionState/Serialization/HttpSessionStateBaseWrapper.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices/SessionState/Serialization/HttpSessionStateBaseWrapper.cs
@@ -2,12 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
-using System.Web.SessionState;
 
 namespace Microsoft.AspNetCore.SystemWebAdapters.SessionState;
 


### PR DESCRIPTION
It appears that some session providers on the framework side may not be able to iterate over the keys while grabbing items as it may throw an InvalidOperationException with the error: Collection was modified after the enumerator was instantiated. Even though it appears that this should not happen, we'll copy the keys over before grabbing items from the collection so this can't happen.

Fixes #556
