### PR TITLE
Add two missing methods for VirtualPathProvider

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Generated/Ref.Standard.cs
@@ -1004,10 +1004,12 @@ namespace System.Web.Hosting
         public virtual bool DirectoryExists(string virtualDir) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public virtual bool FileExists(string virtualPath) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public virtual System.Web.Caching.CacheDependency GetCacheDependency(string virtualPath, System.Collections.IEnumerable virtualPathDependencies, System.DateTime utcStart) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        public virtual string GetCacheKey(string virtualPath) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public virtual System.Web.Hosting.VirtualDirectory GetDirectory(string virtualDir) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public virtual System.Web.Hosting.VirtualFile GetFile(string virtualPath) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         public virtual string GetFileHash(string virtualPath, System.Collections.IEnumerable virtualPathDependencies) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
         protected virtual void Initialize() { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
+        public static System.IO.Stream OpenFile(string virtualPath) { throw new System.PlatformNotSupportedException("Only supported when running on ASP.NET Core or System.Web");}
     }
 }
 namespace System.Web.Security

--- a/src/Microsoft.AspNetCore.SystemWebAdapters/Hosting/VirtualPathProvider.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters/Hosting/VirtualPathProvider.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
+using System.IO;
 using System.Web.Caching;
 using System.Web.Util;
 
@@ -53,6 +54,12 @@ public abstract class VirtualPathProvider
 
     public virtual VirtualDirectory? GetDirectory(string virtualDir) => Previous?.GetDirectory(virtualDir);
 
+    public virtual string? GetCacheKey(string virtualPath)
+    {
+        // By default, return null, meaning use a key based on the virtual path
+        return null;
+    }
+
     public virtual string CombineVirtualPaths(string basePath, string relativePath)
     {
         if (string.IsNullOrEmpty(basePath))
@@ -64,5 +71,15 @@ public abstract class VirtualPathProvider
 
         // By default, just combine them normally
         return VirtualPathUtility.Combine(baseDir, relativePath);
+    }
+
+    /*
+     * Helper method to open a file from its virtual path
+     */
+    public static Stream? OpenFile(string virtualPath)
+    {
+        VirtualPathProvider? vpathProvider = HostingEnvironment.VirtualPathProvider;
+        VirtualFile? vfile = vpathProvider?.GetFileWithCheck(virtualPath);
+        return vfile?.Open();
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the systemweb-adapters repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](../CONTRIBUTING.md) and [Code of Conduct](../CODE-OF-CONDUCT.md).
- [x] You've included unit tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

**PR Title**
Add two missing methods for VirtualPathProvider

**PR Description**
- GetCacheKey
- OpenFile