### PR TITLE
Overwrite previous key if `RegisterKey` is called twice

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters.Abstractions/SessionState/Serialization/JsonSessionSerializerOptions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.Abstractions/SessionState/Serialization/JsonSessionSerializerOptions.cs
@@ -42,5 +42,5 @@ public class JsonSessionSerializerOptions
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <param name="key"></param>
-    public void RegisterKey<T>(string key) => KnownKeys.Add(key, typeof(T));
+    public void RegisterKey<T>(string key) => KnownKeys[key] = typeof(T);
 }

--- a/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/SessionState/Serialization/JsonSessionKeySerializerTests.cs
+++ b/test/Microsoft.AspNetCore.SystemWebAdapters.CoreServices.Tests/SessionState/Serialization/JsonSessionKeySerializerTests.cs
@@ -358,6 +358,37 @@ public class JsonSessionKeySerializerTests
         Assert.True(result2);
     }
 
+    [Fact]
+    public void RegisterKey()
+    {
+        // Arrange
+        var options = new JsonSessionSerializerOptions();
+
+        // Act
+        options.RegisterKey<int>("key");
+
+        // Assert
+        var item = Assert.Single(options.KnownKeys);
+        Assert.Equal(typeof(int), item.Value);
+        Assert.Equal("key", item.Key);
+    }
+
+    [Fact]
+    public void RegisterKeySameName()
+    {
+        // Arrange
+        var options = new JsonSessionSerializerOptions();
+
+        // Act
+        options.RegisterKey<int>("key");
+        options.RegisterKey<int>("key");
+
+        // Assert
+        var item = Assert.Single(options.KnownKeys);
+        Assert.Equal(typeof(int), item.Value);
+        Assert.Equal("key", item.Key);
+    }
+
     private sealed class Type1
     {
     }


### PR DESCRIPTION
Previously, this would just throw, so we'll let the last one win.

Fixes #504
