### PR TITLE
Add generic constraint for AddHttpApplication

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpApplication/HttpApplicationExtensions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.CoreServices/HttpApplication/HttpApplicationExtensions.cs
@@ -61,6 +61,7 @@ public static class HttpApplicationExtensions
     }
 
     public static ISystemWebAdapterBuilder AddHttpApplication<TApp>(this ISystemWebAdapterBuilder builder)
+        where TApp : HttpApplication
     {
         ArgumentNullException.ThrowIfNull(builder);
 


### PR DESCRIPTION
This adds a generic constraint for HttpApplication for one of the overloads of `AddHttpApplication`. The other overload has it, but this one does not. Things will fail at run time if someone is using it with a non-`HttpApplication` derived type, so this will move error to compile time.