### PR TITLE
Make ISessionSerializer internal

### DIFF
--- a/src/Services/SessionState/ISessionSerializer.cs
+++ b/src/Services/SessionState/ISessionSerializer.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.SystemWebAdapters.SessionState.Serialization;
 
-public interface ISessionSerializer
+internal interface ISessionSerializer
 {
     Task<ISessionState?> DeserializeAsync(Stream stream, CancellationToken token);
 


### PR DESCRIPTION
As part of getting changeset session state serialization working, we need to make changes to this interface. It's not what we expect people to use now for implementing session serialization customizations (instead use ISessionKeySerializer), so until we know what that will look like, it'll be internal.
