### PR TITLE
Use UsingMSBuildSDKSystemWeb property to avoid ASPIRE004 warning.

### DIFF
--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -16,10 +16,14 @@
     <GeneratedBindingRedirectsAction>Overwrite</GeneratedBindingRedirectsAction>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!-- The framework projects trigger this warning -->
-    <NoWarn>ASPIRE004;$(NoWarn)</NoWarn>
-  </PropertyGroup>
+  <!-- Ensure target exists for non net projects -->
+  <Target Name="GetTargetFrameworksWithPlatformForSingleTargetFramework" />
+  <!-- Suppress APIRE004 warning by setting _IsExecutable to true in MSBuild.SDK.SystemWeb based projects -->
+  <Target Name="SupressApire004" BeforeTargets="GetTargetFrameworksWithPlatformForSingleTargetFramework">
+    <PropertyGroup Condition="'$(UsingMSBuildSDKSystemWeb)' == 'true'">
+      <_IsExecutable>true</_IsExecutable>
+    </PropertyGroup>
+  </Target>
   
   <PropertyGroup>
     <NoWarn>$(NoWarn);NU1507;NU1902</NoWarn>


### PR DESCRIPTION
Cleaner way of handing APIRE004 issue instead of supressing the warning.

This sets the property `_IsExecutable` on projects based on `MSBuild.SDK.SystemWeb` when calling the `GetTargetFrameworksWithPlatformForSingleTargetFramework` target.

This target is used in the call to get `AdditionalPropertiesFromProject` which is then used in the `GetNonExecutableReferences` task which returns project references which have this set to false. 
`_ValidateAspireHostProjectResources` then triggers the `ASPIRE004` warning for each such project.

https://github.com/dotnet/aspire/blob/ad77802ef553c1e146512588ab05d08453d7e381/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.in.targets#L115-L183

This does require `MSBuild.SDK.SystemWeb` >= 4.0.97 but `global.json` sets version 4.0.104