### PR TITLE
Only check src directory for changed APIs

### DIFF
--- a/update_apis.ps1
+++ b/update_apis.ps1
@@ -4,10 +4,22 @@ param($config = "release")
 
 $project = "src\Microsoft.AspNetCore.SystemWebAdapters\Microsoft.AspNetCore.SystemWebAdapters.csproj"
 
+Write-Host "Generating reference source"
 dotnet build --no-incremental $project -c $config -f net8.0 /p:GenerateStandard=true
+
+Write-Host "Generating type forwards"
 dotnet build --no-incremental $project -c $config -f net8.0 /p:GenerateTypeForwards=true
 
+Write-Host "Verifying all APIs are up to date"
+
 # Script will have an error if there are git changes
-if(git status --porcelain){
+$output = git status src --porcelain
+
+if($output){
+  Write-Host "There are changes in the git repository. Please run locally and then commit the changes."
+  Write-Host "Changes detected:"
+  Write-Host $output
   exit 1
 }
+
+Write-Host "No changes detected for APIs"


### PR DESCRIPTION
There is a build step that verifies APIs have been added to the different targets. It does this by verifying that after updating the APIs, there are no changes to the git directory. The official build is failing on this, probably as it has added something to the repo during build that is causing the detection to fail. However, we only care if changes are to the src, so this update to only verify there as well as being a bit more verbose for the logs.
