### PR TITLE
Add unofficial pipeline

### DIFF
--- a/azure-pipelines-unofficial.yml
+++ b/azure-pipelines-unofficial.yml
@@ -1,0 +1,207 @@
+variables:
+  - name: Build.Repository.Clean
+    value: true
+  - name: _TeamName
+    value: AspNetCore
+  - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
+    value: true
+  - name: _HelixType
+    value: build/product
+  - name: _DotNetArtifactsCategory
+    value: .NETCore
+
+  # Variables to automatically handle build pools
+  - template: /eng/common/templates-official/variables/pool-providers.yml@self
+
+  # Variables for internal Official builds
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - name: _HelixSource
+      value: official/aspnet/AspLabs/$(Build.SourceBranch)
+
+resources:
+  containers:
+  - container: LinuxContainer
+    image: mcr.microsoft.com/dotnet-buildtools-prereqs:ubuntu-18.04-c103199-20180628134610
+    options: --init # This ensures all the stray defunct processes are reaped.
+  repositories:
+  # Repo: 1ESPipelineTemplates/1ESPipelineTemplates
+  - repository: 1esPipelines
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+trigger: none
+
+pr: none
+
+
+extends:
+  template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
+  parameters:
+    sdl:
+      sourceAnalysisPool:
+        name: NetCore1ESPool-Internal
+        image: windows.vs2022preview.amd64
+        os: windows
+    stages:
+    - stage: build
+      displayName: Build
+      jobs:
+      - template: /eng/common/templates-official/jobs/jobs.yml@self
+        parameters:
+          enablePublishBuildArtifacts: false
+          enablePublishTestResults: true
+          enablePublishBuildAssets: false
+          enablePublishUsingPipelines: false
+          helixRepo: dotnet/SystemWeb-Adapters
+          # Align w/ Maestro++ default channel when generating software bills of materials (SBOMs).
+          PackageVersion: 6.0.0
+          # enableMicrobuild can't be read from a user-defined variable (Azure DevOps limitation)
+          ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+            enableMicrobuild: true
+          jobs:
+          - job: Windows
+            pool:
+              name: NetCore1ESPool-Internal
+              image: windows.vs2022preview.amd64
+              os: windows
+            variables:
+            - name: _HelixBuildConfig
+              value: $(_BuildConfig)
+            strategy:
+              matrix:
+                Release:
+                  _BuildConfig: Release
+                  ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+                    _SignType: test
+                    _BuildArgs: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName) /p:OfficialBuildId=$(Build.BuildNumber)
+                      /p:DotNetPublishUsingPipelines=false
+                      /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
+                      /p:DotNetPublishToBlobFeed=false
+            steps:
+            - task: NuGetCommand@2
+              displayName: 'Clear NuGet caches'
+              condition: succeeded()
+              inputs:
+                command: custom
+                arguments: 'locals all -clear'
+            - script: eng\common\cibuild.cmd
+                -configuration $(_BuildConfig)
+                -prepareMachine
+                $(_BuildArgs)
+              name: Build
+              displayName: Build
+              condition: succeeded()
+            - task: PowerShell@2
+              inputs:
+                filePath: update_apis.ps1
+                argument: -c $(_BuildConfig)
+              name: VerifyTypeForwardsRef
+              displayName: Verify TypeForwards/Reference assembly
+              condition: succeeded()
+            - task: PublishTestResults@2
+              displayName: Publish xUnit Test Results
+              condition: always()
+              continueOnError: true
+              inputs:
+                testRunner: xunit
+                testResultsFiles: 'artifacts/TestResults/$(_BuildConfig)/*.xml'
+            - task: 1ES.PublishPipelineArtifact@1
+              displayName: Publish Packages
+              condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
+              continueOnError: true
+              inputs:
+                artifactName: Packages_$(Agent.Os)_$(Agent.JobName)
+                path: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)'
+            - task: 1ES.PublishPipelineArtifact@1
+              displayName: Publish Logs
+              condition: always()
+              continueOnError: true
+              inputs:
+                artifactName: Logs_$(Agent.Os)_$(Agent.JobName)
+                path: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
+
+          - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+            - job: macOS
+              pool:
+                name: Azure Pipelines
+                image: macOS-latest
+                os: macOS
+              strategy:
+                matrix:
+                  release:
+                    _BuildConfig: Release
+              variables:
+              - name: _HelixBuildConfig
+                value: $(_BuildConfig)
+              steps:
+              - script: eng/common/cibuild.sh
+                  --configuration $(_BuildConfig)
+                  --prepareMachine
+                name: Build
+                displayName: Build
+                condition: succeeded()
+              - task: PowerShell@2
+                inputs:
+                  filePath: update_apis.ps1
+                  argument: -c $(_BuildConfig)
+                name: VerifyTypeForwardsRef
+                displayName: Verify TypeForwards/Reference assembly
+                condition: succeeded()
+              - task: PublishTestResults@2
+                displayName: Publish xUnit Test Results
+                condition: always()
+                continueOnError: true
+                inputs:
+                  testRunner: xunit
+                  testResultsFiles: 'artifacts/TestResults/$(_BuildConfig)/*.xml'
+              - task: 1ES.PublishPipelineArtifact@1
+                displayName: Publish Logs
+                condition: always()
+                continueOnError: true
+                inputs:
+                  artifactName: Logs_$(Agent.Os)_$(Agent.JobName)
+                  path: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
+
+          - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+            - job: Linux
+              pool:
+                name: NetCore1ESPool-Internal
+                image: 1es-mariner-2
+                container: LinuxContainer
+                os: linux
+              strategy:
+                matrix:
+                  release:
+                    _BuildConfig: Release
+              variables:
+              - name: _HelixBuildConfig
+                value: $(_BuildConfig)
+              steps:
+              - script: eng/common/cibuild.sh
+                  --configuration $(_BuildConfig)
+                  --prepareMachine
+                name: Build
+                displayName: Build
+                condition: succeeded()
+              - task: PowerShell@2
+                inputs:
+                  filePath: update_apis.ps1
+                  argument: -c $(_BuildConfig)
+                name: VerifyTypeForwardsRef
+                displayName: Verify TypeForwards/Reference assembly
+                condition: succeeded()
+              - task: PublishTestResults@2
+                displayName: Publish xUnit Test Results
+                condition: always()
+                continueOnError: true
+                inputs:
+                  testRunner: xunit
+                  testResultsFiles: 'artifacts/TestResults/$(_BuildConfig)/*.xml'
+              - task: 1ES.PublishPipelineArtifact@1
+                displayName: Publish Logs
+                condition: always()
+                continueOnError: true
+                inputs:
+                  artifactName: Logs_$(Agent.Os)_$(Agent.JobName)
+                  path: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'


### PR DESCRIPTION
Adds .yml to be used by the new unofficial dev pipeline. Identical to the official pipeline, but with SignType=test, and no publishing.