### PR TITLE
Marking Aspire packages as preview and update branding to 2.1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -6,9 +6,9 @@
   </PropertyGroup>
   <PropertyGroup>
     <MajorVersion>2</MajorVersion>
-    <MinorVersion>0</MinorVersion>
-    <PatchVersion>1</PatchVersion>
-    <PreReleaseVersionLabel>preview1</PreReleaseVersionLabel>
+    <MinorVersion>1</MinorVersion>
+    <PatchVersion>0</PatchVersion>
+    <PreReleaseVersionLabel>rtw</PreReleaseVersionLabel>
     <DotNetFinalVersionKind Condition="'$(PreReleaseVersionLabel)' == 'rtw'">release</DotNetFinalVersionKind>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/Aspire.Hosting.IncrementalMigration/Aspire.Hosting.IncrementalMigration.csproj
+++ b/src/Aspire.Hosting.IncrementalMigration/Aspire.Hosting.IncrementalMigration.csproj
@@ -6,6 +6,9 @@
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <EnablePackageValidation>true</EnablePackageValidation>
+    <!-- This package won't produce a stable version -->
+    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
+    <PreReleaseVersionLabel>preview.1</PreReleaseVersionLabel>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Aspire.Microsoft.AspNetCore.SystemWebAdapters/Aspire.Microsoft.AspNetCore.SystemWebAdapters.csproj
+++ b/src/Aspire.Microsoft.AspNetCore.SystemWebAdapters/Aspire.Microsoft.AspNetCore.SystemWebAdapters.csproj
@@ -6,6 +6,9 @@
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <EnablePackageValidation>true</EnablePackageValidation>
+    <!-- This package won't produce a stable version -->
+    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
+    <PreReleaseVersionLabel>preview.1</PreReleaseVersionLabel>
   </PropertyGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">


### PR DESCRIPTION
This pull request updates versioning information for the upcoming release and marks two packages as pre-release only. The changes ensure that the main version numbers reflect the new release and that specific packages are not published as stable versions.

Versioning updates:

* Updated `MajorVersion`, `MinorVersion`, `PatchVersion`, and `PreReleaseVersionLabel` in `eng/Versions.props` to reflect the new release (`2.1.0-rtw`).

Pre-release package configuration:

* Added `<SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>` and set `<PreReleaseVersionLabel>preview.1</PreReleaseVersionLabel>` in `src/Aspire.Hosting.IncrementalMigration/Aspire.Hosting.IncrementalMigration.csproj` to prevent stable package publication.
* Added `<SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>` and set `<PreReleaseVersionLabel>preview.1</PreReleaseVersionLabel>` in `src/Aspire.Microsoft.AspNetCore.SystemWebAdapters/Aspire.Microsoft.AspNetCore.SystemWebAdapters.csproj` to prevent stable package publication.

cc: @twsouthwick 