### PR TITLE
Support HostApplicationBuildersSettings for framework application (#665)

### DIFF
--- a/src/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices/Hosting/ConfigurationManagerConfigExtensions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices/Hosting/ConfigurationManagerConfigExtensions.cs
@@ -46,21 +46,25 @@ internal static class ConfigurationManagerConfigExtensions
     public static IConfigurationManager UseHostingEnvironmentFallback(this IConfigurationManager configuration)
     {
         List<KeyValuePair<string, string?>>? optionList = null;
+
         if (configuration[HostDefaults.ApplicationKey] is null)
         {
             optionList = new();
             optionList.Add(new KeyValuePair<string, string?>(HostDefaults.ApplicationKey, HostingEnvironment.SiteName));
         }
+
         if (configuration[HostDefaults.EnvironmentKey] is null && (HostingEnvironment.IsDevelopmentEnvironment || IsIISExpress()))
         {
             optionList ??= new();
             optionList.Add(new KeyValuePair<string, string?>(HostDefaults.EnvironmentKey, Environments.Development));
         }
+
         if (configuration[HostDefaults.ContentRootKey] is null)
         {
             optionList ??= new();
             optionList.Add(new KeyValuePair<string, string?>(HostDefaults.ContentRootKey, HostingEnvironment.ApplicationPhysicalPath));
         }
+
         if (optionList is not null)
         {
             configuration.AddInMemoryCollection(optionList);

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices/Hosting/ConfigurationManagerConfigExtensions.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices/Hosting/ConfigurationManagerConfigExtensions.cs
@@ -65,6 +65,7 @@ internal static class ConfigurationManagerConfigExtensions
         {
             configuration.AddInMemoryCollection(optionList);
         }
+
         static bool IsIISExpress()
         {
             using var currentProcess = Process.GetCurrentProcess();

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices/Hosting/HttpApplicationHost.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices/Hosting/HttpApplicationHost.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
-using System.Web.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -30,29 +28,26 @@ public sealed class HttpApplicationHost : IHost
 
     public static HttpApplicationHostBuilder CreateBuilder()
     {
-        var config = new ConfigurationManager();
+        return CreateBuilder(new HostApplicationBuilderSettings());
+    }
 
-        config.AddConfigurationManager();
-
-        var builder = new HostApplicationBuilder(new HostApplicationBuilderSettings()
+    internal static HttpApplicationHostBuilder CreateBuilder(HostApplicationBuilderSettings settings)
+    {
+        if (settings is null)
         {
-            Configuration = config,
-            ApplicationName = HostingEnvironment.SiteName,
-            ContentRootPath = HostingEnvironment.ApplicationPhysicalPath,
-            EnvironmentName = HostingEnvironment.IsDevelopmentEnvironment || IsIISExpress() ? Environments.Development : Environments.Production
-        });
+            throw new ArgumentNullException(nameof(settings));
+        }
+
+        settings.Configuration ??= new ConfigurationManager();
+        settings.Configuration.AddConfigurationManager();
+        settings.Configuration.UseHostingEnvironmentFallback();
+
+        var builder = new HostApplicationBuilder(settings);
 
         builder.Services.AddSingleton<IHostLifetime, HttpApplicationLifetime>();
         builder.Services.AddConfigurationAccessor();
 
         return new(builder);
-
-        static bool IsIISExpress()
-        {
-            using var currentProcess = Process.GetCurrentProcess();
-
-            return string.Equals(currentProcess.ProcessName, "iisexpress", StringComparison.Ordinal);
-        }
     }
 
     public static void RegisterHost(Action<HttpApplicationHostBuilder> configure)

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices/Hosting/HttpApplicationHost.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices/Hosting/HttpApplicationHost.cs
@@ -31,7 +31,7 @@ public sealed class HttpApplicationHost : IHost
         return CreateBuilder(new HostApplicationBuilderSettings());
     }
 
-    public static HttpApplicationHostBuilder CreateBuilder(HostApplicationBuilderSettings settings)
+    internal static HttpApplicationHostBuilder CreateBuilder(HostApplicationBuilderSettings settings)
     {
         if (settings is null)
         {

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices/Hosting/HttpApplicationHost.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices/Hosting/HttpApplicationHost.cs
@@ -31,7 +31,7 @@ public sealed class HttpApplicationHost : IHost
         return CreateBuilder(new HostApplicationBuilderSettings());
     }
 
-    internal static HttpApplicationHostBuilder CreateBuilder(HostApplicationBuilderSettings settings)
+    public static HttpApplicationHostBuilder CreateBuilder(HostApplicationBuilderSettings settings)
     {
         if (settings is null)
         {

--- a/src/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices/Hosting/HttpApplicationHost.cs
+++ b/src/Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices/Hosting/HttpApplicationHost.cs
@@ -26,10 +26,7 @@ public sealed class HttpApplicationHost : IHost
         _current = this;
     }
 
-    public static HttpApplicationHostBuilder CreateBuilder()
-    {
-        return CreateBuilder(new HostApplicationBuilderSettings());
-    }
+    public static HttpApplicationHostBuilder CreateBuilder() => CreateBuilder(new HostApplicationBuilderSettings());
 
     internal static HttpApplicationHostBuilder CreateBuilder(HostApplicationBuilderSettings settings)
     {


### PR DESCRIPTION
This updates HttpApplicationHost.CreateBuilder to more closely match HostApplicationBuilder's constructor.  Supports setting any HostDefaults value via configuration or a HostApplicationBuildersSettings instance. This allows even more patterns used in modern ASP.NET Core applications to be available in ASP.NET Framework, including setting the application name and environment.