### PR TITLE
Upgrade to Arcade V4 publishing

### DIFF
--- a/azure-pipelines-public.yml
+++ b/azure-pipelines-public.yml
@@ -39,7 +39,7 @@ stages:
       enablePublishBuildArtifacts: true
       enablePublishTestResults: true
       enablePublishBuildAssets: true
-      enablePublishUsingPipelines: true
+      publishingVersion: 4
       helixRepo: dotnet/SystemWeb-Adapters
       # Align w/ Maestro++ default channel when generating software bills of materials (SBOMs).
       PackageVersion: 6.0.0

--- a/azure-pipelines-unofficial.yml
+++ b/azure-pipelines-unofficial.yml
@@ -52,7 +52,6 @@ extends:
           enablePublishBuildArtifacts: false
           enablePublishTestResults: true
           enablePublishBuildAssets: false
-          enablePublishUsingPipelines: false
           helixRepo: dotnet/SystemWeb-Adapters
           # Align w/ Maestro++ default channel when generating software bills of materials (SBOMs).
           PackageVersion: 6.0.0
@@ -75,7 +74,6 @@ extends:
                   ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
                     _SignType: test
                     _BuildArgs: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName) /p:OfficialBuildId=$(Build.BuildNumber)
-                      /p:DotNetPublishUsingPipelines=false
                       /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
                       /p:DotNetPublishToBlobFeed=false
             steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,7 +58,7 @@ extends:
           enablePublishBuildArtifacts: true
           enablePublishTestResults: true
           enablePublishBuildAssets: true
-          enablePublishUsingPipelines: true
+          publishingVersion: 4
           helixRepo: dotnet/SystemWeb-Adapters
           # Align w/ Maestro++ default channel when generating software bills of materials (SBOMs).
           PackageVersion: 6.0.0
@@ -67,6 +67,7 @@ extends:
             enableMicrobuild: true
           jobs:
           - job: Windows
+            enablePublishing: true
             pool:
               name: NetCore1ESPool-Internal
               image: windows.vs2022preview.amd64
@@ -81,7 +82,6 @@ extends:
                   ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
                     _SignType: real
                     _BuildArgs: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName) /p:OfficialBuildId=$(Build.BuildNumber)
-                      /p:DotNetPublishUsingPipelines=true
                       /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
                       /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
                       /p:DotNetPublishToBlobFeed=true
@@ -216,7 +216,7 @@ extends:
     - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
       - template: eng\common\templates-official\post-build\post-build.yml@self
         parameters:
-          publishingInfraVersion: 3
+          publishingInfraVersion: 4
           # Symbol validation isn't being very reliable lately. This should be enabled back
           # once this issue is resolved: https://github.com/dotnet/arcade/issues/2871
           enableSymbolValidation: false

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
    <PropertyGroup>
-      <PublishingVersion>3</PublishingVersion>
+      <PublishingVersion>4</PublishingVersion>
    </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary
- switch MSBuild publishing to PublishingVersion 4
- update official/public pipeline YAML to use V4 publishing settings
- remove legacy DotNetPublishUsingPipelines wiring and move post-build validation to publishingInfraVersion 4

## Validation tracking
- Official validation build: [dotnet.systemweb-adapters / 20260422.1](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1391529) - succeeded
- Promotion build: Not yet available from this PR validation path. AzDO build 1391529 did not emit a `Publish using Darc` stage or BAR ID tag, so downstream promotion has not run yet.
- Asset comparison: Not yet available because there is no promoted BAR build from this PR to compare against a prior passing official build. This still needs to be completed before merge under the updated V4 guidance.
- Tracker: https://github.com/dotnet/arcade/issues/16697