### PR TITLE
Upgrade to V4 arcade publishing

### DIFF
--- a/azure-pipelines-public.yml
+++ b/azure-pipelines-public.yml
@@ -39,7 +39,6 @@ stages:
       enablePublishBuildArtifacts: true
       enablePublishTestResults: true
       enablePublishBuildAssets: true
-      enablePublishUsingPipelines: true
       helixRepo: dotnet/SystemWeb-Adapters
       # Align w/ Maestro++ default channel when generating software bills of materials (SBOMs).
       PackageVersion: 6.0.0

--- a/azure-pipelines-unofficial.yml
+++ b/azure-pipelines-unofficial.yml
@@ -41,7 +41,7 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: NetCore1ESPool-Internal
-        image: windows.vs2022preview.amd64
+        image: windows.vs2022.amd64
         os: windows
     stages:
     - stage: build
@@ -52,7 +52,6 @@ extends:
           enablePublishBuildArtifacts: false
           enablePublishTestResults: true
           enablePublishBuildAssets: false
-          enablePublishUsingPipelines: false
           helixRepo: dotnet/SystemWeb-Adapters
           # Align w/ Maestro++ default channel when generating software bills of materials (SBOMs).
           PackageVersion: 6.0.0
@@ -63,7 +62,7 @@ extends:
           - job: Windows
             pool:
               name: NetCore1ESPool-Internal
-              image: windows.vs2022preview.amd64
+              image: windows.vs2022.amd64
               os: windows
             variables:
             - name: _HelixBuildConfig
@@ -75,7 +74,6 @@ extends:
                   ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
                     _SignType: test
                     _BuildArgs: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName) /p:OfficialBuildId=$(Build.BuildNumber)
-                      /p:DotNetPublishUsingPipelines=false
                       /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
                       /p:DotNetPublishToBlobFeed=false
             steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,7 @@ extends:
         enabled: true
       sourceAnalysisPool:
         name: NetCore1ESPool-Internal
-        image: windows.vs2022preview.amd64
+        image: windows.vs2022.amd64
         os: windows
     stages:
     - stage: build
@@ -55,10 +55,10 @@ extends:
       jobs:
       - template: /eng/common/templates-official/jobs/jobs.yml@self
         parameters:
-          enablePublishBuildArtifacts: true
+          enablePublishBuildArtifacts: false
           enablePublishTestResults: true
           enablePublishBuildAssets: true
-          enablePublishUsingPipelines: true
+          publishingVersion: 4
           helixRepo: dotnet/SystemWeb-Adapters
           # Align w/ Maestro++ default channel when generating software bills of materials (SBOMs).
           PackageVersion: 6.0.0
@@ -67,9 +67,10 @@ extends:
             enableMicrobuild: true
           jobs:
           - job: Windows
+            enablePublishing: true
             pool:
               name: NetCore1ESPool-Internal
-              image: windows.vs2022preview.amd64
+              image: windows.vs2022.amd64
               os: windows
             variables:
             - name: _HelixBuildConfig
@@ -81,7 +82,6 @@ extends:
                   ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
                     _SignType: real
                     _BuildArgs: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName) /p:OfficialBuildId=$(Build.BuildNumber)
-                      /p:DotNetPublishUsingPipelines=true
                       /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
                       /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
                       /p:DotNetPublishToBlobFeed=true
@@ -216,10 +216,7 @@ extends:
     - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
       - template: eng\common\templates-official\post-build\post-build.yml@self
         parameters:
-          publishingInfraVersion: 3
+          publishingInfraVersion: 4
           # Symbol validation isn't being very reliable lately. This should be enabled back
           # once this issue is resolved: https://github.com/dotnet/arcade/issues/2871
           enableSymbolValidation: false
-          # This is to enable SDL runs part of Post-Build Validation Stage
-          SDLValidationParameters:
-            enable: false

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
    <PropertyGroup>
-      <PublishingVersion>3</PublishingVersion>
+      <PublishingVersion>4</PublishingVersion>
    </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Upgrade to V4 Arcade Publishing

This PR migrates dotnet/systemweb-adapters from Arcade V3 publishing to V4 publishing.

### Changes
| File | Change |
|------|--------|
| `eng/Publishing.props` | `PublishingVersion` 3 → 4 |
| `azure-pipelines.yml` | Removed `enablePublishUsingPipelines`, added `publishingVersion: 4`, added `enablePublishing: true` on Windows job, removed `/p:DotNetPublishUsingPipelines=true` from build args, `publishingInfraVersion` 3 → 4, removed unsupported `SDLValidationParameters`, set `enablePublishBuildArtifacts: false` (repo has custom log publishing), updated pool image `vs2022preview` → `vs2022` |
| `azure-pipelines-public.yml` | Removed `enablePublishUsingPipelines` |
| `azure-pipelines-unofficial.yml` | Removed `enablePublishUsingPipelines`, removed `/p:DotNetPublishUsingPipelines=false` from build args, updated pool image `vs2022preview` → `vs2022` |

## Validation tracking
- Official validation build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2957984 (succeeded)
- Promotion build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2958017 (partiallySucceeded — expected V3 fallback download warnings only)
- Asset comparison: baseline BAR ID 301244 (build 20260210.3) vs new BAR ID 311502 (build 20260422.7) — **15 assets each, counts match, identities aligned** (7 packages + 7 symbol packages + 1 manifest)
- Tracker: https://github.com/dotnet/arcade/issues/16697