### PR TITLE
Fix references to code of conduct.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,6 @@ Security issues and bugs should be reported privately, via email, to the Microso
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md)
 
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
-
 # Trademarks
 
 This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft trademarks or logos is subject to and must follow Microsoft's Trademark & Brand Guidelines. Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship. Any use of third-party trademarks or logos are subject to those third-party's policies.


### PR DESCRIPTION
See dotnet/org-policy-violations#6337

Fixes violation of policy [PR16](https://github.com/dotnet/org-policy/blob/main/doc/PR16.md), by removing reference to a wrong code of conduct in the README.