### PR TITLE
Update dependencies to latest within current major version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,9 +7,9 @@
 
   <!-- Product -->
   <ItemGroup>
-    <PackageVersion Include="Aspire.Hosting" Version="13.0.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.11.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
+    <PackageVersion Include="Aspire.Hosting" Version="13.4.6" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
     <PackageVersion Include="Microsoft.DotNet.BuildTools.GenAPI" Version="3.0.0-preview4-06015-01" />
     <PackageVersion Include="System.Security.Principal.Windows" Version="5.0.0" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />
@@ -21,112 +21,112 @@
     <PackageVersion Include="Microsoft.Owin.Security" Version="4.2.3" />
     <PackageVersion Include="Microsoft.Owin.Host.SystemWeb" Version="4.2.3" />
     <PackageVersion Include="Microsoft.Owin.Security.Cookies" Version="4.2.3" />
-    <PackageVersion Include="Microsoft.Owin.Security.Interop" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.Owin.Security.Interop" Version="2.3.11" />
     <PackageVersion Include="Microsoft.Owin.Security.OAuth" Version="4.2.3" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.242" />
+    <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.298" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net472' ">
-    <PackageVersion Include="Microsoft.AspNetCore.Owin" Version="8.0.22" />
+    <PackageVersion Include="Microsoft.AspNetCore.Owin" Version="8.0.28" />
     <PackageVersion Include="System.Runtime.Caching" Version="8.0.1" />
     <PackageVersion Include="System.Text.Json" Version="8.0.6" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="8.0.22" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="8.0.28" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
-    <PackageVersion Include="Microsoft.AspNetCore.Owin" Version="9.0.11" />
-    <PackageVersion Include="System.Runtime.Caching" Version="9.0.11" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.Owin" Version="9.0.17" />
+    <PackageVersion Include="System.Runtime.Caching" Version="9.0.17" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.17" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
-    <PackageVersion Include="Microsoft.AspNetCore.Owin" Version="10.0.0" />
-    <PackageVersion Include="System.Runtime.Caching" Version="10.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Owin" Version="10.0.9" />
+    <PackageVersion Include="System.Runtime.Caching" Version="10.0.9" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.9" />
   </ItemGroup>
 
   <!-- Testing -->
   <ItemGroup>
-    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.0.0" />
-    <PackageVersion Include="Autofac.Extras.Moq" Version="6.0.0" />
-    <PackageVersion Include="AutoFixture" Version="4.15.0" />
-    <PackageVersion Include="Basic.Reference.Assemblies" Version="1.4.5" />
-    <PackageVersion Include="coverlet.collector" Version="3.1.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.11.0" />
+    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.4.6" />
+    <PackageVersion Include="Autofac.Extras.Moq" Version="6.1.1" />
+    <PackageVersion Include="AutoFixture" Version="4.18.1" />
+    <PackageVersion Include="Basic.Reference.Assemblies" Version="1.8.9" />
+    <PackageVersion Include="coverlet.collector" Version="3.2.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.14.0" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.3" />
-    <PackageVersion Include="Microsoft.Playwright.Xunit" Version="1.52.0" />
-    <PackageVersion Include="Moq" Version="4.16.1" />
-    <PackageVersion Include="NUnit.Analyzers" Version="3.3.0" />
+    <PackageVersion Include="Microsoft.Playwright.Xunit" Version="1.61.0" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="NUnit.Analyzers" Version="3.10.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.21" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.28" />
     <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="9.0.10" />
-    <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="9.0.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="9.0.17" />
+    <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="9.0.17" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.0" />
-    <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.9" />
+    <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="10.0.9" />
   </ItemGroup>
 
   <!-- Samples -->
   <ItemGroup>
     <PackageVersion Include="Antlr" Version="3.5.0.2" />
-    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.0.0" />
+    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.4.6" />
     <PackageVersion Include="AspNet.ScriptManager.bootstrap" Version="5.2.3" />
     <PackageVersion Include="AspNet.ScriptManager.jQuery" Version="3.7.1" />
     <PackageVersion Include="AspNet.ScriptManager.jQuery.UI.Combined" Version="1.13.2" />
-    <PackageVersion Include="bootstrap" Version="5.3.6" />
-    <PackageVersion Include="C3D.Extensions.Aspire.IISExpress" Version="0.2.20" />
-    <PackageVersion Include="EntityFramework" Version="6.5.1" />
+    <PackageVersion Include="bootstrap" Version="5.3.8" />
+    <PackageVersion Include="C3D.Extensions.Aspire.IISExpress" Version="0.3.9" />
+    <PackageVersion Include="EntityFramework" Version="6.5.2" />
     <PackageVersion Include="jQuery" Version="3.7.1" />
     <PackageVersion Include="Microsoft.AspNet.FriendlyUrls" Version="1.0.2" />
     <PackageVersion Include="Microsoft.AspNet.Identity.Core" Version="2.2.4" />
     <PackageVersion Include="Microsoft.AspNet.Identity.EntityFramework" Version="2.2.4" />
     <PackageVersion Include="Microsoft.AspNet.Identity.Owin" Version="2.2.4" />
-    <PackageVersion Include="Microsoft.AspNet.Mvc" Version="5.2.7" />
+    <PackageVersion Include="Microsoft.AspNet.Mvc" Version="5.3.0" />
     <PackageVersion Include="Microsoft.AspNet.ScriptManager.MSAjax" Version="5.0.0" />
     <PackageVersion Include="Microsoft.AspNet.ScriptManager.WebForms" Version="5.0.0" />
     <PackageVersion Include="Microsoft.AspNet.Web.Optimization" Version="1.1.3" />
     <PackageVersion Include="Microsoft.AspNet.Web.Optimization.WebForms" Version="1.1.3" />
-    <PackageVersion Include="Microsoft.AspNet.WebApi" Version="5.2.7" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.SystemWeb" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.AspNet.WebApi" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.SystemWeb" Version="2.3.11" />
     <PackageVersion Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" Version="4.1.0" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.jQuery.Unobtrusive.Validation" Version="3.2.11" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.7.0" />
+    <PackageVersion Include="Microsoft.jQuery.Unobtrusive.Validation" Version="3.3.0" />
     <PackageVersion Include="Microsoft.Net.Compilers.Toolset" Version="4.14.0" />
     <PackageVersion Include="Microsoft.Web.Infrastructure" Version="2.0.1" />
     <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageVersion Include="Modernizr" Version="2.8.3" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageVersion Include="System.Security.AccessControl" Version="6.0.1" />
     <PackageVersion Include="WebGrease" Version="1.6.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.13.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNet" Version="1.13.0-rc.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.13.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.13.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.13.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.12.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNet" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.16.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net472'  OR '$(TargetFramework)' == 'net481' OR '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="8.0.22" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.CustomElements" Version="8.0.22" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="8.0.28" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.CustomElements" Version="8.0.28" />
     <PackageVersion Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="8.0.22" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.22" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.22" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.22" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.28" />
     <PackageVersion Include="Microsoft.Extensions.FileProviders.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.FileProviders.Composite" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="8.0.0" />
@@ -137,50 +137,50 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.22" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.22" />
     <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
     <PackageVersion Include="System.Text.Encodings.Web" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="9.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.CustomElements" Version="9.0.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="9.0.17" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.CustomElements" Version="9.0.17" />
     <PackageVersion Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="9.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Abstractions" Version="9.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Composite" Version="9.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="9.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.17" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.17" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.17" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.17" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Abstractions" Version="9.0.17" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Composite" Version="9.0.17" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="9.0.17" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.17" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.17" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.10.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.11" />
-    <PackageVersion Include="System.Text.Encodings.Web" Version="9.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.17" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.17" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.17" />
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.17" />
+    <PackageVersion Include="System.Text.Encodings.Web" Version="9.0.17" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.CustomElements" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.CustomElements" Version="10.0.9" />
     <PackageVersion Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Composite" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.13.1" />
-    <PackageVersion Include="System.Text.Encodings.Web" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Composite" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.9" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
+    <PackageVersion Include="System.Text.Encodings.Web" Version="10.0.9" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -53,12 +53,12 @@
     <PackageVersion Include="Aspire.Hosting.Testing" Version="13.4.6" />
     <PackageVersion Include="Autofac.Extras.Moq" Version="6.1.1" />
     <PackageVersion Include="AutoFixture" Version="4.18.1" />
-    <PackageVersion Include="Basic.Reference.Assemblies" Version="1.8.9" />
+    <PackageVersion Include="Basic.Reference.Assemblies" Version="1.4.5" />
     <PackageVersion Include="coverlet.collector" Version="3.2.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.14.0" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.3" />
     <PackageVersion Include="Microsoft.Playwright.Xunit" Version="1.61.0" />
-    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="Moq" Version="4.16.1" />
     <PackageVersion Include="NUnit.Analyzers" Version="3.10.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Updates all dependencies in `Directory.Packages.props` to the latest available versions **within their current major version**.

## Summary
79 package versions were bumped. Updates were sourced from nuget.org, keeping each package within its existing major version. Packages already at the latest within-major version were left unchanged, and no downgrades were made (some `Microsoft.Extensions.*` 8.0.x packages have no higher public release on nuget.org and were left as-is).

Notable changes:
- `Aspire.Hosting`/`Aspire.Hosting.Testing`/`Aspire.Hosting.SqlServer`: 13.0.0 → 13.4.6
- `Microsoft.CodeAnalysis*`: 4.11.0 → 4.14.0
- `OpenTelemetry.*` instrumentation/exporter: 1.13.0 → 1.16.0 (prerelease pins for AspNet/SqlClient moved to stable 1.16.0)
- `OpenTelemetry.Extensions.Hosting`: 1.9.0/1.13.1 → 1.16.0
- ASP.NET Core packages (Owin, DataProtection, TestHost, Authentication.Negotiate, Components.CustomElements, Diagnostics.HealthChecks): 8.0.x/9.0.x/10.0.x servicing bumps
- `AutoFixture` 4.15.0 → 4.18.1, `Microsoft.Playwright.Xunit` 1.52.0 → 1.61.0, `NUnit.Analyzers` 3.3.0 → 3.10.0, and more

## Excluded (breaking changes)
Two candidate bumps were reverted because they broke the build:
- `Basic.Reference.Assemblies` 1.4.5 → 1.8.9 — removed `ReferenceAssemblies.Net60`, causing CS0117 in `VerifyMembersHaveSameSignature.cs`.
- `Moq` 4.16.1 → 4.20.72 — added nullable-reference annotations, causing CS8625 where `null` is passed to `new Mock<MemoryCache>(name, null)` in the caching tests.

Both remain at their original versions.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>