### PR TITLE
Bump 2019 build image to 2022 equivalent

### DIFF
--- a/azure-pipelines-public.yml
+++ b/azure-pipelines-public.yml
@@ -46,7 +46,7 @@ stages:
       - job: Windows
         pool:
           name: $(DncEngPublicBuildPool)
-          demands: ImageOverride -equals 1es-windows-2019-open
+          demands: ImageOverride -equals 1es-windows-2022-open
         variables:
         - name: _HelixBuildConfig
           value: $(_BuildConfig)


### PR DESCRIPTION
Updates the Windows 2019 build image to its 2022 equivalent in the pipeline `.yml` files (excluding `eng/common`).

## Change
`azure-pipelines-public.yml`: public build pool image `1es-windows-2019-open` → `1es-windows-2022-open`.

This was the only `2019` image reference outside of `eng/common`. The internal pipelines already target 2022 images (`windows.vs2022.amd64`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>